### PR TITLE
fix pop-ups blocked issuse

### DIFF
--- a/web/src/components/utils.js
+++ b/web/src/components/utils.js
@@ -30,20 +30,26 @@ export async function onOIDCClicked(auth_url, client_id, openInNewTab = false) {
   }
 }
 
-export async function onGitHubOAuthClicked(github_client_id) {
+export async function onGitHubOAuthClicked(github_client_id, openInNewTab = false) {
   const state = await getOAuthState();
   if (!state) return;
-  window.open(
-    `https://github.com/login/oauth/authorize?client_id=${github_client_id}&state=${state}&scope=user:email`,
-  );
+  const url = `https://github.com/login/oauth/authorize?client_id=${github_client_id}&state=${state}&scope=user:email`;
+  if (openInNewTab) {
+    window.open(url);
+  } else {
+    window.location.href = url;
+  }
 }
 
-export async function onLinuxDOOAuthClicked(linuxdo_client_id) {
+export async function onLinuxDOOAuthClicked(linuxdo_client_id, openInNewTab = false) {
   const state = await getOAuthState();
   if (!state) return;
-  window.open(
-    `https://connect.linux.do/oauth2/authorize?response_type=code&client_id=${linuxdo_client_id}&state=${state}`,
-  );
+  const url = `https://connect.linux.do/oauth2/authorize?response_type=code&client_id=${linuxdo_client_id}&state=${state}`;
+  if (openInNewTab) {
+    window.open(url);
+  } else {
+    window.location.href = url;
+  }
 }
 
 let channelModels = undefined;


### PR DESCRIPTION
I found that the third party login authorization uses the `window.open` method, which is considered **pop-ups** and is blocked by default on safari because it's usually considered an **ad pop-up**, so I modified it to the `window.location.href `redirection method, while also retaining the winow.open, and just adding the call to add true, such as `onGitHubOAuthClicked(status.github_client_id, true)`