### PR TITLE
Fix conflict with identical model IDs across different prefix channels

### DIFF
--- a/middleware/distributor.go
+++ b/middleware/distributor.go
@@ -63,6 +63,11 @@ func GetPrefixChannels(group string) map[string][]*model.Channel {
 	return getPrefixChannels(group)
 }
 
+// SelectChannelByPrefix is the exported version of selectChannelByPrefix for use by other packages
+func SelectChannelByPrefix(group, prefix, originalModel string) (*model.Channel, error) {
+	return selectChannelByPrefix(group, prefix, originalModel)
+}
+
 // ResetChannelKeyIndex resets the round-robin key index for a specific channel
 // This can be called when a channel's keys are updated
 func ResetChannelKeyIndex(channelId int) {


### PR DESCRIPTION
This PR fixes [#69](https://github.com/Veloera/Veloera/issues/69) by correctly handling cases where different prefix channels include the same base model ID. It ensures that all prefixed variations are preserved and routed appropriately, avoiding model resolution conflicts caused by overwriting.