### PR TITLE
Update prefix cache after channel changes

### DIFF
--- a/controller/channel.go
+++ b/controller/channel.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 	"veloera/common"
+	"veloera/middleware"
 	"veloera/model"
 
 	"github.com/gin-gonic/gin"
@@ -301,6 +302,9 @@ func AddChannel(c *gin.Context) {
 		return
 	}
 
+	// refresh prefix cache for the groups this channel belongs to
+	middleware.RefreshPrefixChannelsCache(channel.Group)
+
 	c.JSON(http.StatusOK, gin.H{
 		"success": true,
 		"message": "",
@@ -371,6 +375,20 @@ func DisableTagChannels(c *gin.Context) {
 		})
 		return
 	}
+	if channels, err := model.GetChannelsByTag(channelTag.Tag, false); err == nil {
+		groupSet := make(map[string]struct{})
+		for _, ch := range channels {
+			for _, g := range strings.Split(ch.Group, ",") {
+				g = strings.TrimSpace(g)
+				if g != "" {
+					groupSet[g] = struct{}{}
+				}
+			}
+		}
+		for g := range groupSet {
+			middleware.RefreshPrefixChannelsCache(g)
+		}
+	}
 	c.JSON(http.StatusOK, gin.H{
 		"success": true,
 		"message": "",
@@ -395,6 +413,20 @@ func EnableTagChannels(c *gin.Context) {
 			"message": err.Error(),
 		})
 		return
+	}
+	if channels, err := model.GetChannelsByTag(channelTag.Tag, false); err == nil {
+		groupSet := make(map[string]struct{})
+		for _, ch := range channels {
+			for _, g := range strings.Split(ch.Group, ",") {
+				g = strings.TrimSpace(g)
+				if g != "" {
+					groupSet[g] = struct{}{}
+				}
+			}
+		}
+		for g := range groupSet {
+			middleware.RefreshPrefixChannelsCache(g)
+		}
 	}
 	c.JSON(http.StatusOK, gin.H{
 		"success": true,
@@ -505,6 +537,9 @@ func UpdateChannel(c *gin.Context) {
 		})
 		return
 	}
+
+	// refresh prefix cache as channel configuration may change
+	middleware.RefreshPrefixChannelsCache(channel.Group)
 	c.JSON(http.StatusOK, gin.H{
 		"success": true,
 		"message": "",

--- a/middleware/distributor.go
+++ b/middleware/distributor.go
@@ -79,6 +79,18 @@ func ResetChannelKeyIndex(channelId int) {
 	delete(channelKeysHash, channelId)
 }
 
+// RefreshPrefixChannelsCache refreshes prefix cache for one or multiple groups.
+// Groups should be a comma separated string, empty entries are ignored.
+func RefreshPrefixChannelsCache(groups string) {
+	for _, g := range strings.Split(groups, ",") {
+		g = strings.TrimSpace(g)
+		if g == "" {
+			continue
+		}
+		refreshPrefixChannelsCache(g)
+	}
+}
+
 // refreshPrefixChannelsCache refreshes the prefix channels cache for a given group
 func refreshPrefixChannelsCache(group string) map[string][]*model.Channel {
 	var channels []*model.Channel
@@ -394,7 +406,7 @@ func SetupContextForSelectedChannel(c *gin.Context, channel *model.Channel, mode
 	c.Set("channel_id", channel.Id)
 	c.Set("channel_name", channel.Name)
 	c.Set("channel_type", channel.Type)
-c.Set("channel_create_time", channel.CreatedTime)
+	c.Set("channel_create_time", channel.CreatedTime)
 	c.Set("channel_setting", channel.GetSetting())
 	c.Set("param_override", channel.GetParamOverride())
 


### PR DESCRIPTION
## Summary
- refresh prefix cache when channels are added or updated
- refresh prefix cache when enabling or disabling channels by tag
- provide `RefreshPrefixChannelsCache` helper

## Testing
- `go test ./...` *(fails: pattern web/dist: no matching files found)*

------
https://chatgpt.com/codex/tasks/task_b_684165670aec832ca796335e66d2152f