### PR TITLE
fix: display duplicate models with and without prefixes

### DIFF
--- a/controller/model.go
+++ b/controller/model.go
@@ -239,66 +239,69 @@ func ListModels(c *gin.Context) {
 				}
 			}
 		}
-	} else {
-		models := model.GetGroupModels(group)
-		addedModels := make(map[string]bool)
+	} else { // modelLimitEnable is false
+		models := model.GetGroupModels(group) // Models available to the user's group
+		processedModels := make(map[string]bool) // Tracks models already added to userOpenAiModels to prevent duplicates
 
-		// First add all models with prefixes
-		for baseModel, prefixedModels := range modelPrefixMap {
-			// Check if the base model is in the allowed models for this group
-			isAllowed := false
+		// First, add all models from channels with prefixes
+		for baseModel, prefixedModelNameVersions := range modelPrefixMap {
+			isBaseModelAllowed := false
 			for _, groupModel := range models {
 				if groupModel == baseModel {
-					isAllowed = true
+					isBaseModelAllowed = true
 					break
 				}
 			}
 
-			if isAllowed {
-				// Add all prefixed versions of this model
-				for _, prefixedModel := range prefixedModels {
-					if _, ok := openAIModelsMap[baseModel]; ok {
-						modelInfo := openAIModelsMap[baseModel]
-						// Create a copy and replace ID with prefixed model
-						prefixedModelInfo := modelInfo
-						prefixedModelInfo.Id = prefixedModel
-						userOpenAiModels = append(userOpenAiModels, prefixedModelInfo)
+			if isBaseModelAllowed {
+				for _, prefixedModelName := range prefixedModelNameVersions {
+					if processedModels[prefixedModelName] {
+						continue // Skip if this specific prefixed model was already added
+					}
+					// Construct and add the prefixed model to userOpenAiModels
+					if modelData, ok := openAIModelsMap[baseModel]; ok { // Use baseModel for template
+						modelInfo := modelData // Make a copy to modify
+						modelInfo.Id = prefixedModelName
+						modelInfo.Root = baseModel // Ensure Root is the base model
+						userOpenAiModels = append(userOpenAiModels, modelInfo)
 					} else {
 						userOpenAiModels = append(userOpenAiModels, dto.OpenAIModels{
-							Id:         prefixedModel,
+							Id:         prefixedModelName,
 							Object:     "model",
 							Created:    1626777600,
-							OwnedBy:    "custom",
+							OwnedBy:    "custom", // Or derive from channel if possible
 							Permission: permission,
 							Root:       baseModel,
 							Parent:     nil,
 						})
 					}
+					processedModels[prefixedModelName] = true
 				}
-				addedModels[baseModel] = true
 			}
 		}
 
-		// Then add remaining models without prefixes
-		for _, s := range models {
-			// Skip if already added with a prefix
-			if addedModels[s] {
-				continue
+		// Second, add all models available to the group (including non-prefixed ones)
+		// that haven't been added yet.
+		for _, modelName := range models {
+			if processedModels[modelName] {
+				continue // Skip if this model (prefixed or non-prefixed) was already added
 			}
 
-			if _, ok := openAIModelsMap[s]; ok {
-				userOpenAiModels = append(userOpenAiModels, openAIModelsMap[s])
+			// Construct and add the non-prefixed model to userOpenAiModels
+			if modelData, ok := openAIModelsMap[modelName]; ok {
+				userOpenAiModels = append(userOpenAiModels, modelData)
 			} else {
 				userOpenAiModels = append(userOpenAiModels, dto.OpenAIModels{
-					Id:         s,
+					Id:         modelName,
 					Object:     "model",
 					Created:    1626777600,
-					OwnedBy:    "custom",
+					OwnedBy:    "custom", // Or derive from channel if possible
 					Permission: permission,
-					Root:       s,
+					Root:       modelName,
 					Parent:     nil,
 				})
 			}
+			processedModels[modelName] = true
 		}
 	}
 


### PR DESCRIPTION
When a model ID is available from two channels, one with a prefix and one without, the model list API (`/api/models`) would previously only show the prefixed version. This was due to the base model ID being marked as "processed" after its prefixed version was added, preventing the non-prefixed version from being listed.

This commit modifies the `ListModels` function in `controller/model.go`. When `modelLimitEnable` is false, the logic now uses a `processedModels` map that tracks the exact model strings (including prefixes) that have been added to the list. This ensures that if "prefix/modelA" is added, "modelA" (from a non-prefixed channel) can still be added to the list if it's accessible by you.

This change allows you to see and potentially use both the prefixed and non-prefixed versions of a model if they are provided through different channels.