### PR TITLE
Fix: Remove duplicate gin import in relay-gemini.go

### DIFF
--- a/relay/channel/gemini/relay-gemini.go
+++ b/relay/channel/gemini/relay-gemini.go
@@ -9,8 +9,6 @@ import (
 	"strings"
 	"unicode/utf8"
 
-	"github.com/gin-gonic/gin"
-
 	"veloera/common"
 	"veloera/constant"
 	"veloera/dto"


### PR DESCRIPTION
The file relay/channel/gemini/relay-gemini.go contained a duplicate import statement for "github.com/gin-gonic/gin". This caused a "gin redeclared" error during the build process.

This commit removes the redundant import on line 12, resolving the build error.

Output: