### PR TITLE
Fix: Prevent multiple redemptions of the same code under high concurr…

### DIFF
--- a/controller/user.go
+++ b/controller/user.go
@@ -8,7 +8,6 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
-	"sync"
 	"veloera/common"
 	"veloera/model"
 	"veloera/setting"
@@ -956,11 +955,7 @@ type topUpRequest struct {
 	Key string `json:"key"`
 }
 
-var topUpLock = sync.Mutex{}
-
 func TopUp(c *gin.Context) {
-	topUpLock.Lock()
-	defer topUpLock.Unlock()
 	req := topUpRequest{}
 	err := c.ShouldBindJSON(&req)
 	if err != nil {


### PR DESCRIPTION
…ency

The previous implementation of the redemption code/gift code endpoint (/api/user/topup) had a potential race condition. Under high load, submitting multiple requests for the same code in a short time could lead to the code being redeemed multiple times, incorrectly incrementing your balance multiple times.

This commit addresses the issue by:
1. Implementing a Redis-based distributed lock in the core `model.Redeem` function.
   - A lock key specific to the redemption code (e.g., `rloc:<redemption_key>`) is used with `SETNX`.
   - This ensures that only one application instance can attempt to process a specific redemption code at any given time.
   - A lock timeout (10s) is used to prevent deadlocks.
   - If the lock cannot be acquired, an appropriate error ("操作过于频繁，请稍后再试") is returned to you.
2. Removing the previous application-level global `sync.Mutex` (`topUpLock`) from `controller/user.go`. The new distributed lock in the model layer is more robust, especially for multi-instance deployments.
3. Removing an unnecessary `common.RandomSleep()` call from `model.Redeem` which was detrimental to performance and did not contribute to correctness.

The existing database transaction with `FOR UPDATE` in `model.Redeem` remains as a defense-in-depth measure for data integrity during the database operations.