### PR TITLE
Add stream_support pseudo streaming

### DIFF
--- a/constant/channel_setting.go
+++ b/constant/channel_setting.go
@@ -4,4 +4,6 @@ var (
 	ForceFormat                     = "force_format"        // ForceFormat 强制格式化为OpenAI格式
 	ChanelSettingProxy              = "proxy"               // Proxy 代理
 	ChannelSettingThinkingToContent = "thinking_to_content" // ThinkingToContent
+	ChannelSettingStreamSupport     = "stream_support"      // StreamSupport 控制上游流式请求行为
+	StreamSupportNonStreamOnly      = "NON_STREAM_ONLY"     // StreamSupport 仅非流式请求
 )

--- a/new-api-stuffs/docs/channel/other_setting.md
+++ b/new-api-stuffs/docs/channel/other_setting.md
@@ -13,6 +13,9 @@
 3. thinking_to_content
    - 用于标识是否将思考内容`reasoning_content`转换为`<think>`标签拼接到内容中返回
    - 类型为布尔值，设置为 true 时启用思考内容转换
+4. stream_support
+   - 控制与上游的流式请求方式，可选值为 `default` 或 `NON_STREAM_ONLY`
+   - 当设置为 `NON_STREAM_ONLY` 且客户端请求流式时，将改为向上游发起非流式请求，并以伪流形式返回结果
 
 --------------------------------------------------------------
 
@@ -24,7 +27,8 @@
 {
     "force_format": true,
    "thinking_to_content": true,
-    "proxy": "socks5://xxxxxxx"
+    "proxy": "socks5://xxxxxxx",
+    "stream_support": "NON_STREAM_ONLY"
 }
 ```
 

--- a/relay/channel/gemini/relay-gemini.go
+++ b/relay/channel/gemini/relay-gemini.go
@@ -13,6 +13,7 @@ import (
 	"veloera/common"
 	"veloera/constant"
 	"veloera/dto"
+	openaichannel "veloera/relay/channel/openai"
 	relaycommon "veloera/relay/common"
 	"veloera/relay/helper"
 	"veloera/service"
@@ -844,61 +845,20 @@ func GeminiEmbeddingHandler(c *gin.Context, resp *http.Response, info *relaycomm
 }
 
 func GeminiChatPseudoStreamHandler(c *gin.Context, resp *http.Response, info *relaycommon.RelayInfo) (*dto.OpenAIErrorWithStatusCode, *dto.Usage) {
-	responseBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return service.OpenAIErrorWrapper(err, "read_response_body_failed", http.StatusInternalServerError), nil
+	geminiResp, errResp := parseGeminiChatResponse(resp)
+	if errResp != nil {
+		return errResp, nil
 	}
-	err = resp.Body.Close()
-	if err != nil {
-		return service.OpenAIErrorWrapper(err, "close_response_body_failed", http.StatusInternalServerError), nil
-	}
-	var geminiResponse GeminiChatResponse
-	if err = json.Unmarshal(responseBody, &geminiResponse); err != nil {
-		return service.OpenAIErrorWrapper(err, "unmarshal_response_body_failed", http.StatusInternalServerError), nil
-	}
-	if len(geminiResponse.Candidates) == 0 {
-		return &dto.OpenAIErrorWithStatusCode{
-			Error: dto.OpenAIError{
-				Message: "No candidates returned",
-				Type:    "server_error",
-				Param:   "",
-				Code:    500,
-			},
-			StatusCode: resp.StatusCode,
-		}, nil
-	}
-	fullTextResponse := responseGeminiChat2OpenAI(&geminiResponse)
+
+	fullTextResponse := responseGeminiChat2OpenAI(geminiResp)
 	fullTextResponse.Model = info.UpstreamModelName
-	usage := &dto.Usage{
-		PromptTokens:     geminiResponse.UsageMetadata.PromptTokenCount,
-		CompletionTokens: geminiResponse.UsageMetadata.CandidatesTokenCount,
-		TotalTokens:      geminiResponse.UsageMetadata.TotalTokenCount,
-	}
-	if geminiResponse.UsageMetadata.ThoughtsTokenCount > 0 {
-		usage.CompletionTokenDetails.ReasoningTokens = geminiResponse.UsageMetadata.ThoughtsTokenCount
-	}
+	usage := buildGeminiUsage(geminiResp)
 	fullTextResponse.Usage = *usage
 
 	helper.SetEventStreamHeaders(c)
 	info.SetFirstResponseTime()
 
-	// build openai stream chunk
-	var streamResp dto.ChatCompletionsStreamResponse
-	streamResp.Id = fullTextResponse.Id
-	streamResp.Object = "chat.completion.chunk"
-	streamResp.Created = fullTextResponse.Created
-	streamResp.Model = fullTextResponse.Model
-	streamResp.Choices = make([]dto.ChatCompletionsStreamResponseChoice, len(fullTextResponse.Choices))
-	for i, ch := range fullTextResponse.Choices {
-		var choice dto.ChatCompletionsStreamResponseChoice
-		choice.Index = ch.Index
-		finishReason := ch.FinishReason
-		choice.FinishReason = &finishReason
-		choice.Delta.Role = "assistant"
-		choice.Delta.SetContentString(ch.Message.StringContent())
-		streamResp.Choices[i] = choice
-	}
-
+	streamResp := openaichannel.BuildStreamChunkFromTextResponse(&fullTextResponse)
 	_ = helper.ObjectData(c, streamResp)
 	if info.ShouldIncludeUsage {
 		final := helper.GenerateFinalUsageResponse(helper.GetResponseID(c), common.GetTimestamp(), info.UpstreamModelName, *usage)
@@ -906,4 +866,37 @@ func GeminiChatPseudoStreamHandler(c *gin.Context, resp *http.Response, info *re
 	}
 	helper.Done(c)
 	return nil, usage
+}
+
+func parseGeminiChatResponse(resp *http.Response) (*GeminiChatResponse, *dto.OpenAIErrorWithStatusCode) {
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, service.OpenAIErrorWrapper(err, "read_response_body_failed", http.StatusInternalServerError)
+	}
+	if err = resp.Body.Close(); err != nil {
+		return nil, service.OpenAIErrorWrapper(err, "close_response_body_failed", http.StatusInternalServerError)
+	}
+	var geminiResponse GeminiChatResponse
+	if err = json.Unmarshal(body, &geminiResponse); err != nil {
+		return nil, service.OpenAIErrorWrapper(err, "unmarshal_response_body_failed", http.StatusInternalServerError)
+	}
+	if len(geminiResponse.Candidates) == 0 {
+		return nil, &dto.OpenAIErrorWithStatusCode{
+			Error:      dto.OpenAIError{Message: "No candidates returned", Type: "server_error", Code: 500},
+			StatusCode: resp.StatusCode,
+		}
+	}
+	return &geminiResponse, nil
+}
+
+func buildGeminiUsage(gResp *GeminiChatResponse) *dto.Usage {
+	usage := &dto.Usage{
+		PromptTokens:     gResp.UsageMetadata.PromptTokenCount,
+		CompletionTokens: gResp.UsageMetadata.CandidatesTokenCount,
+		TotalTokens:      gResp.UsageMetadata.TotalTokenCount,
+	}
+	if gResp.UsageMetadata.ThoughtsTokenCount > 0 {
+		usage.CompletionTokenDetails.ReasoningTokens = gResp.UsageMetadata.ThoughtsTokenCount
+	}
+	return usage
 }

--- a/relay/channel/openai/relay-openai.go
+++ b/relay/channel/openai/relay-openai.go
@@ -865,3 +865,66 @@ func preConsumeUsage(ctx *gin.Context, info *relaycommon.RelayInfo, usage *dto.R
 	err := service.PreWssConsumeQuota(ctx, info, usage)
 	return err
 }
+
+func OpenaiPseudoStreamHandler(c *gin.Context, resp *http.Response, info *relaycommon.RelayInfo) (*dto.OpenAIErrorWithStatusCode, *dto.Usage) {
+	var simpleResponse dto.OpenAITextResponse
+	responseBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return service.OpenAIErrorWrapper(err, "read_response_body_failed", http.StatusInternalServerError), nil
+	}
+	err = resp.Body.Close()
+	if err != nil {
+		return service.OpenAIErrorWrapper(err, "close_response_body_failed", http.StatusInternalServerError), nil
+	}
+	err = common.DecodeJson(responseBody, &simpleResponse)
+	if err != nil {
+		return service.OpenAIErrorWrapper(err, "unmarshal_response_body_failed", http.StatusInternalServerError), nil
+	}
+	if simpleResponse.Error != nil && simpleResponse.Error.Type != "" {
+		return &dto.OpenAIErrorWithStatusCode{
+			Error:      *simpleResponse.Error,
+			StatusCode: resp.StatusCode,
+		}, nil
+	}
+
+	if simpleResponse.Usage.TotalTokens == 0 || (simpleResponse.Usage.PromptTokens == 0 && simpleResponse.Usage.CompletionTokens == 0) {
+		completionTokens := 0
+		for _, choice := range simpleResponse.Choices {
+			ctkm, _ := service.CountTextToken(choice.Message.StringContent()+choice.Message.ReasoningContent+choice.Message.Reasoning, info.UpstreamModelName)
+			completionTokens += ctkm
+		}
+		simpleResponse.Usage = dto.Usage{
+			PromptTokens:     info.PromptTokens,
+			CompletionTokens: completionTokens,
+			TotalTokens:      info.PromptTokens + completionTokens,
+		}
+	}
+
+	helper.SetEventStreamHeaders(c)
+	info.SetFirstResponseTime()
+
+	// build a stream chunk from the full response
+	var streamResp dto.ChatCompletionsStreamResponse
+	streamResp.Id = simpleResponse.Id
+	streamResp.Object = "chat.completion.chunk"
+	streamResp.Created = simpleResponse.Created
+	streamResp.Model = simpleResponse.Model
+	streamResp.Choices = make([]dto.ChatCompletionsStreamResponseChoice, len(simpleResponse.Choices))
+	for i, ch := range simpleResponse.Choices {
+		var choice dto.ChatCompletionsStreamResponseChoice
+		choice.Index = ch.Index
+		finishReason := ch.FinishReason
+		choice.FinishReason = &finishReason
+		choice.Delta.Role = "assistant"
+		choice.Delta.SetContentString(ch.Message.StringContent())
+		streamResp.Choices[i] = choice
+	}
+
+	_ = helper.ObjectData(c, streamResp)
+	if info.ShouldIncludeUsage {
+		final := helper.GenerateFinalUsageResponse(helper.GetResponseID(c), common.GetTimestamp(), info.UpstreamModelName, simpleResponse.Usage)
+		_ = helper.ObjectData(c, final)
+	}
+	helper.Done(c)
+	return nil, &simpleResponse.Usage
+}

--- a/relay/channel/openai/relay-openai.go
+++ b/relay/channel/openai/relay-openai.go
@@ -867,43 +867,61 @@ func preConsumeUsage(ctx *gin.Context, info *relaycommon.RelayInfo, usage *dto.R
 }
 
 func OpenaiPseudoStreamHandler(c *gin.Context, resp *http.Response, info *relaycommon.RelayInfo) (*dto.OpenAIErrorWithStatusCode, *dto.Usage) {
-	var simpleResponse dto.OpenAITextResponse
-	responseBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return service.OpenAIErrorWrapper(err, "read_response_body_failed", http.StatusInternalServerError), nil
-	}
-	err = resp.Body.Close()
-	if err != nil {
-		return service.OpenAIErrorWrapper(err, "close_response_body_failed", http.StatusInternalServerError), nil
-	}
-	err = common.DecodeJson(responseBody, &simpleResponse)
-	if err != nil {
-		return service.OpenAIErrorWrapper(err, "unmarshal_response_body_failed", http.StatusInternalServerError), nil
-	}
-	if simpleResponse.Error != nil && simpleResponse.Error.Type != "" {
-		return &dto.OpenAIErrorWithStatusCode{
-			Error:      *simpleResponse.Error,
-			StatusCode: resp.StatusCode,
-		}, nil
+	simpleResponse, errResp := parseOpenAITextResponse(resp)
+	if errResp != nil {
+		return errResp, nil
 	}
 
-	if simpleResponse.Usage.TotalTokens == 0 || (simpleResponse.Usage.PromptTokens == 0 && simpleResponse.Usage.CompletionTokens == 0) {
-		completionTokens := 0
-		for _, choice := range simpleResponse.Choices {
-			ctkm, _ := service.CountTextToken(choice.Message.StringContent()+choice.Message.ReasoningContent+choice.Message.Reasoning, info.UpstreamModelName)
-			completionTokens += ctkm
-		}
-		simpleResponse.Usage = dto.Usage{
-			PromptTokens:     info.PromptTokens,
-			CompletionTokens: completionTokens,
-			TotalTokens:      info.PromptTokens + completionTokens,
-		}
-	}
+	fillOpenAIUsage(simpleResponse, info)
 
 	helper.SetEventStreamHeaders(c)
 	info.SetFirstResponseTime()
 
-	// build a stream chunk from the full response
+	streamResp := BuildStreamChunkFromTextResponse(simpleResponse)
+	_ = helper.ObjectData(c, streamResp)
+	if info.ShouldIncludeUsage {
+		final := helper.GenerateFinalUsageResponse(helper.GetResponseID(c), common.GetTimestamp(), info.UpstreamModelName, simpleResponse.Usage)
+		_ = helper.ObjectData(c, final)
+	}
+	helper.Done(c)
+	return nil, &simpleResponse.Usage
+}
+
+func parseOpenAITextResponse(resp *http.Response) (*dto.OpenAITextResponse, *dto.OpenAIErrorWithStatusCode) {
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, service.OpenAIErrorWrapper(err, "read_response_body_failed", http.StatusInternalServerError)
+	}
+	if err = resp.Body.Close(); err != nil {
+		return nil, service.OpenAIErrorWrapper(err, "close_response_body_failed", http.StatusInternalServerError)
+	}
+	var res dto.OpenAITextResponse
+	if err = common.DecodeJson(body, &res); err != nil {
+		return nil, service.OpenAIErrorWrapper(err, "unmarshal_response_body_failed", http.StatusInternalServerError)
+	}
+	if res.Error != nil && res.Error.Type != "" {
+		return nil, &dto.OpenAIErrorWithStatusCode{Error: *res.Error, StatusCode: resp.StatusCode}
+	}
+	return &res, nil
+}
+
+func fillOpenAIUsage(resp *dto.OpenAITextResponse, info *relaycommon.RelayInfo) {
+	if resp.Usage.TotalTokens != 0 && (resp.Usage.PromptTokens != 0 || resp.Usage.CompletionTokens != 0) {
+		return
+	}
+	completionTokens := 0
+	for _, choice := range resp.Choices {
+		ctkm, _ := service.CountTextToken(choice.Message.StringContent()+choice.Message.ReasoningContent+choice.Message.Reasoning, info.UpstreamModelName)
+		completionTokens += ctkm
+	}
+	resp.Usage = dto.Usage{
+		PromptTokens:     info.PromptTokens,
+		CompletionTokens: completionTokens,
+		TotalTokens:      info.PromptTokens + completionTokens,
+	}
+}
+
+func BuildStreamChunkFromTextResponse(simpleResponse *dto.OpenAITextResponse) dto.ChatCompletionsStreamResponse {
 	var streamResp dto.ChatCompletionsStreamResponse
 	streamResp.Id = simpleResponse.Id
 	streamResp.Object = "chat.completion.chunk"
@@ -919,12 +937,5 @@ func OpenaiPseudoStreamHandler(c *gin.Context, resp *http.Response, info *relayc
 		choice.Delta.SetContentString(ch.Message.StringContent())
 		streamResp.Choices[i] = choice
 	}
-
-	_ = helper.ObjectData(c, streamResp)
-	if info.ShouldIncludeUsage {
-		final := helper.GenerateFinalUsageResponse(helper.GetResponseID(c), common.GetTimestamp(), info.UpstreamModelName, simpleResponse.Usage)
-		_ = helper.ObjectData(c, final)
-	}
-	helper.Done(c)
-	return nil, &simpleResponse.Usage
+	return streamResp
 }


### PR DESCRIPTION
## Summary
- add `stream_support` channel setting
- document new option
- implement waiting heartbeat utilities
- implement pseudo-stream handlers for OpenAI and Gemini
- support pseudo stream mode in text relay
- fix pseudo streaming output format

## Testing
- `go fmt ./...`
- `go vet ./...` *(fails: pattern web/dist not found)*
- `go build ./...` *(fails: pattern web/dist not found)*

------
https://chatgpt.com/codex/tasks/task_b_684e85ea28e4832c866e56731f5e3635