### PR TITLE
Fix Gemini pseudo stream parameter

### DIFF
--- a/relay/channel/gemini/relay-gemini.go
+++ b/relay/channel/gemini/relay-gemini.go
@@ -858,7 +858,7 @@ func GeminiChatPseudoStreamHandler(c *gin.Context, resp *http.Response, info *re
 	helper.SetEventStreamHeaders(c)
 	info.SetFirstResponseTime()
 
-	streamResp := openaichannel.BuildStreamChunkFromTextResponse(&fullTextResponse)
+	streamResp := openaichannel.BuildStreamChunkFromTextResponse(fullTextResponse)
 	_ = helper.ObjectData(c, streamResp)
 	if info.ShouldIncludeUsage {
 		final := helper.GenerateFinalUsageResponse(helper.GetResponseID(c), common.GetTimestamp(), info.UpstreamModelName, *usage)


### PR DESCRIPTION
## Summary
- fix Gemini channel's pseudo stream handler to pass text response pointer correctly

## Testing
- `go build ./relay/...`

------
https://chatgpt.com/codex/tasks/task_b_684e97cb42b8832c843731c3d94f96f5