### PR TITLE
Add exemption settings for rate limit and safe check

### DIFF
--- a/middleware/token-rate-limit.go
+++ b/middleware/token-rate-limit.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"time"
 	"veloera/common"
+	"veloera/setting/model_setting"
 
 	"github.com/gin-gonic/gin"
 	"github.com/go-redis/redis/v8"
@@ -116,6 +117,11 @@ func tokenMemoryRateLimitHandler(duration int64, totalMaxCount, successMaxCount 
 func TokenRateLimit() func(c *gin.Context) {
 	return func(c *gin.Context) {
 		if !c.GetBool("token_rate_limit_enabled") {
+			c.Next()
+			return
+		}
+		tokenGroup := c.GetString("token_group")
+		if model_setting.ShouldBypassRateLimit(tokenGroup) {
 			c.Next()
 			return
 		}

--- a/model/option.go
+++ b/model/option.go
@@ -124,6 +124,8 @@ func InitOptionMap() {
 	common.OptionMap["ModelRequestRateLimitEnabled"] = strconv.FormatBool(setting.ModelRequestRateLimitEnabled)
 	common.OptionMap["CheckSensitiveOnPromptEnabled"] = strconv.FormatBool(setting.CheckSensitiveOnPromptEnabled)
 	common.OptionMap["StopOnSensitiveEnabled"] = strconv.FormatBool(setting.StopOnSensitiveEnabled)
+	common.OptionMap["SafeCheckExemptEnabled"] = strconv.FormatBool(setting.SafeCheckExemptEnabled)
+	common.OptionMap["SafeCheckExemptGroup"] = setting.SafeCheckExemptGroup
 	common.OptionMap["SensitiveWords"] = setting.SensitiveWordsToString()
 	common.OptionMap["StreamCacheQueueLength"] = strconv.Itoa(setting.StreamCacheQueueLength)
 	common.OptionMap["AutomaticDisableKeywords"] = operation_setting.AutomaticDisableKeywordsToString()
@@ -273,6 +275,8 @@ func updateOptionMap(key string, value string) (err error) {
 			setting.ModelRequestRateLimitEnabled = boolValue
 		case "StopOnSensitiveEnabled":
 			setting.StopOnSensitiveEnabled = boolValue
+		case "SafeCheckExemptEnabled":
+			setting.SafeCheckExemptEnabled = boolValue
 		case "SMTPSSLEnabled":
 			common.SMTPSSLEnabled = boolValue
 		}
@@ -387,6 +391,8 @@ func updateOptionMap(key string, value string) (err error) {
 		common.QuotaPerUnit, _ = strconv.ParseFloat(value, 64)
 	case "SensitiveWords":
 		setting.SensitiveWordsFromString(value)
+	case "SafeCheckExemptGroup":
+		setting.SafeCheckExemptGroup = value
 	case "AutomaticDisableKeywords":
 		operation_setting.AutomaticDisableKeywordsFromString(value)
 	case "StreamCacheQueueLength":

--- a/relay/relay-audio.go
+++ b/relay/relay-audio.go
@@ -26,7 +26,8 @@ func getAndValidAudioRequest(c *gin.Context, info *relaycommon.RelayInfo) (*dto.
 		if audioRequest.Model == "" {
 			return nil, errors.New("model is required")
 		}
-		if setting.ShouldCheckPromptSensitive() {
+		tokenGroup := c.GetString("token_group")
+		if setting.ShouldCheckPromptSensitiveWithGroup(tokenGroup) {
 			words, err := service.CheckSensitiveInput(audioRequest.Input)
 			if err != nil {
 				common.LogWarn(c, fmt.Sprintf("user sensitive words detected: %s", strings.Join(words, ",")))

--- a/relay/relay-image.go
+++ b/relay/relay-image.go
@@ -60,7 +60,8 @@ func getAndValidImageRequest(c *gin.Context, info *relaycommon.RelayInfo) (*dto.
 	//if imageRequest.N != 0 && (imageRequest.N < 1 || imageRequest.N > 10) {
 	//	return service.OpenAIErrorWrapper(errors.New("n must be between 1 and 10"), "invalid_field_value", http.StatusBadRequest)
 	//}
-	if setting.ShouldCheckPromptSensitive() {
+	tokenGroup := c.GetString("token_group")
+	if setting.ShouldCheckPromptSensitiveWithGroup(tokenGroup) {
 		words, err := service.CheckSensitiveInput(imageRequest.Prompt)
 		if err != nil {
 			common.LogWarn(c, fmt.Sprintf("user sensitive words detected: %s", strings.Join(words, ",")))

--- a/relay/relay-responses.go
+++ b/relay/relay-responses.go
@@ -100,7 +100,8 @@ func validateAndPrepareRequest(c *gin.Context, relayInfo *relaycommon.RelayInfo)
 		return nil, service.OpenAIErrorWrapperLocal(err, "invalid_responses_request", http.StatusBadRequest)
 	}
 
-	if setting.ShouldCheckPromptSensitive() {
+	tokenGroup := c.GetString("token_group")
+	if setting.ShouldCheckPromptSensitiveWithGroup(tokenGroup) {
 		sensitiveWords, err := checkInputSensitive(req, relayInfo)
 		if err != nil {
 			common.LogWarn(c, fmt.Sprintf("user sensitive words detected: %s", strings.Join(sensitiveWords, ", ")))

--- a/relay/relay-text.go
+++ b/relay/relay-text.go
@@ -91,7 +91,8 @@ func TextHelper(c *gin.Context) (openaiErr *dto.OpenAIErrorWithStatusCode) {
 		return service.OpenAIErrorWrapperLocal(err, "invalid_text_request", http.StatusBadRequest)
 	}
 
-	if setting.ShouldCheckPromptSensitive() {
+	tokenGroup := c.GetString("token_group")
+	if setting.ShouldCheckPromptSensitiveWithGroup(tokenGroup) {
 		words, err := checkRequestSensitive(textRequest, relayInfo)
 		if err != nil {
 			common.LogWarn(c, fmt.Sprintf("user sensitive words detected: %s", strings.Join(words, ", ")))

--- a/setting/model_setting/global.go
+++ b/setting/model_setting/global.go
@@ -5,9 +5,13 @@ import (
 )
 
 type GlobalSettings struct {
-	PassThroughRequestEnabled    bool `json:"pass_through_request_enabled"`
-	HideUpstreamErrorEnabled     bool `json:"hide_upstream_error_enabled"`
-	BlockBrowserExtensionEnabled bool `json:"block_browser_extension_enabled"`
+	PassThroughRequestEnabled    bool   `json:"pass_through_request_enabled"`
+	HideUpstreamErrorEnabled     bool   `json:"hide_upstream_error_enabled"`
+	BlockBrowserExtensionEnabled bool   `json:"block_browser_extension_enabled"`
+	RateLimitExemptEnabled       bool   `json:"rate_limit_exempt_enabled"`
+	RateLimitExemptGroup         string `json:"rate_limit_exempt_group"`
+	SafeCheckExemptEnabled       bool   `json:"safe_check_exempt_enabled"`
+	SafeCheckExemptGroup         string `json:"safe_check_exempt_group"`
 }
 
 // 默认配置
@@ -15,6 +19,10 @@ var defaultOpenaiSettings = GlobalSettings{
 	PassThroughRequestEnabled:    false,
 	HideUpstreamErrorEnabled:     false,
 	BlockBrowserExtensionEnabled: false,
+	RateLimitExemptEnabled:       false,
+	RateLimitExemptGroup:         "bulk-ok",
+	SafeCheckExemptEnabled:       false,
+	SafeCheckExemptGroup:         "nsfw-ok",
 }
 
 // 全局实例
@@ -27,4 +35,12 @@ func init() {
 
 func GetGlobalSettings() *GlobalSettings {
 	return &globalSettings
+}
+
+func ShouldBypassRateLimit(group string) bool {
+	return globalSettings.RateLimitExemptEnabled && group == globalSettings.RateLimitExemptGroup
+}
+
+func ShouldBypassSafeCheck(group string) bool {
+	return globalSettings.SafeCheckExemptEnabled && group == globalSettings.SafeCheckExemptGroup
 }

--- a/setting/sensitive.go
+++ b/setting/sensitive.go
@@ -8,6 +8,9 @@ import (
 var CheckSensitiveEnabled = true
 var CheckSensitiveOnPromptEnabled = true
 
+var SafeCheckExemptEnabled = false
+var SafeCheckExemptGroup = "nsfw-ok"
+
 //var CheckSensitiveOnCompletionEnabled = true
 
 // StopOnSensitiveEnabled 如果检测到敏感词，是否立刻停止生成，否则替换敏感词
@@ -74,6 +77,13 @@ func SensitiveWordsFromString(s string) {
 
 func ShouldCheckPromptSensitive() bool {
 	return CheckSensitiveEnabled && CheckSensitiveOnPromptEnabled
+}
+
+func ShouldCheckPromptSensitiveWithGroup(group string) bool {
+	if SafeCheckExemptEnabled && group == SafeCheckExemptGroup {
+		return false
+	}
+	return ShouldCheckPromptSensitive()
 }
 
 //func ShouldCheckCompletionSensitive() bool {

--- a/web/src/components/ModelSetting.js
+++ b/web/src/components/ModelSetting.js
@@ -20,11 +20,15 @@ const ModelSetting = () => {
     'global.pass_through_request_enabled': false,
     'global.hide_upstream_error_enabled': false,
     'global.block_browser_extension_enabled': false,
+    'global.rate_limit_exempt_enabled': false,
+    'global.rate_limit_exempt_group': 'bulk-ok',
+    'global.safe_check_exempt_enabled': false,
+    'global.safe_check_exempt_group': 'nsfw-ok',
     'general_setting.ping_interval_enabled': false,
     'general_setting.ping_interval_seconds': 60,
     'gemini.thinking_adapter_enabled': false,
     'gemini.thinking_adapter_budget_tokens_percentage': 0.6,
-    'gemini.models_supported_thinking_budget': '', 
+    'gemini.models_supported_thinking_budget': '',
   });
 
   let [loading, setLoading] = useState(false);

--- a/web/src/pages/Setting/Model/SettingGlobalModel.js
+++ b/web/src/pages/Setting/Model/SettingGlobalModel.js
@@ -18,6 +18,10 @@ export default function SettingGlobalModel(props) {
     'global.pass_through_request_enabled': false,
     'global.hide_upstream_error_enabled': false,
     'global.block_browser_extension_enabled': false,
+    'global.rate_limit_exempt_enabled': false,
+    'global.rate_limit_exempt_group': 'bulk-ok',
+    'global.safe_check_exempt_enabled': false,
+    'global.safe_check_exempt_group': 'nsfw-ok',
     'general_setting.ping_interval_enabled': false,
     'general_setting.ping_interval_seconds': 60,
   });
@@ -115,26 +119,90 @@ export default function SettingGlobalModel(props) {
                       'global.block_browser_extension_enabled': value,
                     })
                   }
-                  extraText={'是否允许浏览器插件请求, 请注意此判断逻辑不可靠, 并可能误杀!'}
+                  extraText={
+                    '是否允许浏览器插件请求, 请注意此判断逻辑不可靠, 并可能误杀!'
+                  }
                 />
               </Col>
             </Row>
-            
+
+            <Form.Section text={t('规则豁免设置')}>
+              <Row>
+                <Col xs={24} sm={12} md={8} lg={8} xl={8}>
+                  <Form.Switch
+                    label={t('启用速率限制豁免')}
+                    field={'global.rate_limit_exempt_enabled'}
+                    onChange={(value) =>
+                      setInputs({
+                        ...inputs,
+                        'global.rate_limit_exempt_enabled': value,
+                      })
+                    }
+                  />
+                </Col>
+                <Col xs={24} sm={12} md={8} lg={8} xl={8}>
+                  <Form.Input
+                    label={t('豁免分组')}
+                    field={'global.rate_limit_exempt_group'}
+                    onChange={(value) =>
+                      setInputs({
+                        ...inputs,
+                        'global.rate_limit_exempt_group': value,
+                      })
+                    }
+                    disabled={!inputs['global.rate_limit_exempt_enabled']}
+                  />
+                </Col>
+              </Row>
+              <Row>
+                <Col xs={24} sm={12} md={8} lg={8} xl={8}>
+                  <Form.Switch
+                    label={t('启用安全审查豁免')}
+                    field={'global.safe_check_exempt_enabled'}
+                    onChange={(value) =>
+                      setInputs({
+                        ...inputs,
+                        'global.safe_check_exempt_enabled': value,
+                      })
+                    }
+                  />
+                </Col>
+                <Col xs={24} sm={12} md={8} lg={8} xl={8}>
+                  <Form.Input
+                    label={t('豁免分组')}
+                    field={'global.safe_check_exempt_group'}
+                    onChange={(value) =>
+                      setInputs({
+                        ...inputs,
+                        'global.safe_check_exempt_group': value,
+                      })
+                    }
+                    disabled={!inputs['global.safe_check_exempt_enabled']}
+                  />
+                </Col>
+              </Row>
+            </Form.Section>
+
             <Form.Section text={t('连接保活设置')}>
-            <Row style={{ marginTop: 10 }}>
-                  <Col span={24}>
-                    <Banner 
-                      type="warning"
-                      description="警告：启用保活后，如果已经写入保活数据后渠道出错，系统无法重试，如果必须开启，推荐设置尽可能大的Ping间隔"
-                    />
-                  </Col>
-                </Row>
+              <Row style={{ marginTop: 10 }}>
+                <Col span={24}>
+                  <Banner
+                    type='warning'
+                    description='警告：启用保活后，如果已经写入保活数据后渠道出错，系统无法重试，如果必须开启，推荐设置尽可能大的Ping间隔'
+                  />
+                </Col>
+              </Row>
               <Row>
                 <Col xs={24} sm={12} md={8} lg={8} xl={8}>
                   <Form.Switch
                     label={t('启用Ping间隔')}
                     field={'general_setting.ping_interval_enabled'}
-                    onChange={(value) => setInputs({ ...inputs, 'general_setting.ping_interval_enabled': value })}
+                    onChange={(value) =>
+                      setInputs({
+                        ...inputs,
+                        'general_setting.ping_interval_enabled': value,
+                      })
+                    }
                     extraText={'开启后，将定期发送ping数据保持连接活跃'}
                   />
                 </Col>
@@ -142,7 +210,12 @@ export default function SettingGlobalModel(props) {
                   <Form.InputNumber
                     label={t('Ping间隔（秒）')}
                     field={'general_setting.ping_interval_seconds'}
-                    onChange={(value) => setInputs({ ...inputs, 'general_setting.ping_interval_seconds': value })}
+                    onChange={(value) =>
+                      setInputs({
+                        ...inputs,
+                        'general_setting.ping_interval_seconds': value,
+                      })
+                    }
                     min={1}
                     disabled={!inputs['general_setting.ping_interval_enabled']}
                   />


### PR DESCRIPTION
## Summary
- add rate limit & security exemption options in global model settings
- support skipping checks based on token group
- update frontend model settings UI

## Testing
- `pnpm lint`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_b_68626dab95c8832cb66f2e19770af10e