### PR TITLE
fix(Channels): add custom endpoint support to aws bedrock adapter

### DIFF
--- a/relay/channel/aws/relay-aws.go
+++ b/relay/channel/aws/relay-aws.go
@@ -26,11 +26,18 @@ func newAwsClient(c *gin.Context, info *relaycommon.RelayInfo) (*bedrockruntime.
 	ak := awsSecret[0]
 	sk := awsSecret[1]
 	region := awsSecret[2]
-	client := bedrockruntime.New(bedrockruntime.Options{
+
+	options := bedrockruntime.Options{
 		Region:      region,
 		Credentials: aws.NewCredentialsCache(credentials.NewStaticCredentialsProvider(ak, sk, "")),
-	})
+	}
 
+	if info.BaseUrl != "" {
+		baseEndpoint := info.BaseUrl
+		options.BaseEndpoint = &baseEndpoint
+	}
+
+	client := bedrockruntime.New(options)
 	return client, nil
 }
 


### PR DESCRIPTION
This PR fixes aws bedrock custom base url support.
plain and simple.

tested with
```bash
podman build -t veloera:test .
podman run --rm -p 3000:3000 veloera:test
```
pointing towards mitmproxy