### PR TITLE
feat: support -thinking-{budget} to set budget tokens

### DIFF
--- a/relay/channel/gemini/relay-gemini.go
+++ b/relay/channel/gemini/relay-gemini.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"strings"
 	"unicode/utf8"
 
@@ -227,13 +228,6 @@ func CovertGemini2OpenAI(textRequest dto.GeneralOpenAIRequest, info *relaycommon
 		},
 	}
 
-	// Check if the current model supports thinking budget
-	if isModelSupportedThinkingBudget(info.OriginModelName, model_setting.GetGeminiSettings().ModelsSupportedThinkingBudget) {
-		geminiRequest.GenerationConfig.ThinkingConfig = &GeminiThinkingConfig{
-			IncludeThoughts: true,
-		}
-	}
-
 	if model_setting.IsGeminiModelSupportImagine(info.UpstreamModelName) {
 		geminiRequest.GenerationConfig.ResponseModalities = []string{
 			"TEXT",
@@ -241,13 +235,21 @@ func CovertGemini2OpenAI(textRequest dto.GeneralOpenAIRequest, info *relaycommon
 		}
 	}
 
+	// Set thinking budget
 	if model_setting.GetGeminiSettings().ThinkingAdapterEnabled {
-		if geminiRequest.GenerationConfig.ThinkingConfig != nil { // Only apply if ThinkingConfig was instantiated
-			if strings.HasSuffix(info.OriginModelName, "-thinking") {
-				budgetTokens := model_setting.GetGeminiSettings().ThinkingAdapterBudgetTokensPercentage * float64(geminiRequest.GenerationConfig.MaxOutputTokens)
-				if budgetTokens == 0 || budgetTokens > 24576 {
-					budgetTokens = 24576
+		if isModelSupportedThinkingBudget(info.OriginModelName, model_setting.GetGeminiSettings().ModelsSupportedThinkingBudget) {
+			geminiRequest.GenerationConfig.ThinkingConfig = &GeminiThinkingConfig{
+				IncludeThoughts: true,
+			}
+			if strings.Contains(info.OriginModelName, "-thinking-") {
+				parts := strings.SplitN(info.OriginModelName, "-thinking-", 2)
+				if len(parts) == 2 && parts[1] != "" {
+					if budgetTokens, err := strconv.Atoi(parts[1]); err == nil {
+						geminiRequest.GenerationConfig.ThinkingConfig.SetThinkingBudget(budgetTokens)
+					}
 				}
+			} else if strings.HasSuffix(info.OriginModelName, "-thinking") {
+				budgetTokens := model_setting.GetGeminiSettings().ThinkingAdapterBudgetTokensPercentage * float64(geminiRequest.GenerationConfig.MaxOutputTokens)
 				geminiRequest.GenerationConfig.ThinkingConfig.SetThinkingBudget(int(budgetTokens))
 			} else if strings.HasSuffix(info.OriginModelName, "-nothinking") {
 				geminiRequest.GenerationConfig.ThinkingConfig.SetThinkingBudget(0)

--- a/setting/model_setting/gemini.go
+++ b/setting/model_setting/gemini.go
@@ -37,6 +37,7 @@ var defaultGeminiSettings = GeminiSettings{
 		"gemini-2.5-flash-preview-05-20",
 		"gemini-2.5-flash-preview-04-17",
 		"gemini-2.5-pro-preview-06-05",
+		"gemini-2.5-pro",
 	},
 }
 

--- a/web/src/pages/Setting/Model/SettingGeminiModel.js
+++ b/web/src/pages/Setting/Model/SettingGeminiModel.js
@@ -201,8 +201,9 @@ export default function SettingGeminiModel(props) {
                   field={'gemini.thinking_adapter_budget_tokens_percentage'}
                   initValue={''}
                   extraText={t('0.002-1之间的小数')}
-                  min={0.1}
+                  min={0.002}
                   max={1}
+                  step={0.001}
                   onChange={(value) =>
                     setInputs({
                       ...inputs,

--- a/web/src/pages/Setting/Model/SettingGeminiModel.js
+++ b/web/src/pages/Setting/Model/SettingGeminiModel.js
@@ -164,7 +164,8 @@ export default function SettingGeminiModel(props) {
                   {t(
                     "和Claude不同，默认情况下Gemini的思考模型会自动决定要不要思考，就算不开启适配模型也可以正常使用，" +
                     "-nothinking后缀（BudgetTokens=0，思考关闭）也会返回少量的思考token，这是gemini的特性，" +
-                    "如果您需要计费，推荐设置无后缀模型价格按思考价格设置"
+                    "如果您需要计费，推荐设置无后缀模型价格按思考价格设置" + 
+                    "支持使用 {模型}-thinking-{预算} 格式来精确传递思考预算"
                   )}
                 </Text>
               </Col>
@@ -174,7 +175,7 @@ export default function SettingGeminiModel(props) {
                 <Form.Switch
                   label={t('启用Gemini思考后缀适配')}
                   field={'gemini.thinking_adapter_enabled'}
-                  extraText={"适配-thinking和-nothinking后缀"}
+                  extraText={"适配-thinking、-thinking-{budget}和-nothinking后缀"}
                   onChange={(value) =>
                     setInputs({
                       ...inputs,
@@ -196,10 +197,10 @@ export default function SettingGeminiModel(props) {
             <Row>
               <Col xs={24} sm={12} md={8} lg={8} xl={8}>
                 <Form.InputNumber
-                  label={t('请求模型带-thinking后缀的BudgetTokens数（超出24576的部分将被忽略）')}
+                  label={t('思考预算占比')}
                   field={'gemini.thinking_adapter_budget_tokens_percentage'}
                   initValue={''}
-                  extraText={t('0.1-1之间的小数')}
+                  extraText={t('0.002-1之间的小数')}
                   min={0.1}
                   max={1}
                   onChange={(value) =>


### PR DESCRIPTION
this should resolve #128 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for specifying a thinking budget directly in the model name using the "-thinking-{number}" format.
  * Expanded support for the thinking budget feature to include the "gemini-2.5-pro" model.

* **Improvements**
  * Updated the Gemini model settings UI to clarify supported model name formats and improve guidance on thinking budget input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->