### PR TITLE
feat: add moderation settings and enforcement

### DIFF
--- a/model/option.go
+++ b/model/option.go
@@ -147,6 +147,7 @@ func InitOptionMap() {
 	common.OptionMap["StreamCacheQueueLength"] = strconv.Itoa(setting.StreamCacheQueueLength)
 	common.OptionMap["AutomaticDisableKeywords"] = operation_setting.AutomaticDisableKeywordsToString()
 
+	common.OptionMap["moderation_enabled"] = "false"
 	common.OptionMap["moderation_service"] = "veloera"
 	common.OptionMap["moderation_api_url"] = ""
 	common.OptionMap["moderation_api_key"] = ""
@@ -447,6 +448,8 @@ func updateOptionMap(key string, value string) (err error) {
 		common.RebatePercentage, _ = strconv.ParseFloat(value, 64)
 	case "ReverseProxyProvider":
 		common.ReverseProxyProvider = value
+	case "moderation_enabled":
+		setting.ModerationEnabled = value == "true"
 	case "moderation_service":
 		setting.ModerationService = value
 	case "moderation_api_url":

--- a/model/option.go
+++ b/model/option.go
@@ -147,6 +147,14 @@ func InitOptionMap() {
 	common.OptionMap["StreamCacheQueueLength"] = strconv.Itoa(setting.StreamCacheQueueLength)
 	common.OptionMap["AutomaticDisableKeywords"] = operation_setting.AutomaticDisableKeywordsToString()
 
+	common.OptionMap["moderation_service"] = "veloera"
+	common.OptionMap["moderation_api_url"] = ""
+	common.OptionMap["moderation_api_key"] = ""
+	common.OptionMap["moderation_model"] = ""
+	common.OptionMap["moderation_auto_ban"] = "false"
+	common.OptionMap["moderation_no_error"] = "false"
+	common.OptionMap["moderation_reject_message"] = "This request may violate our Terms of Use. If you have any questions, please contact the site administrator."
+
 	// Add custom content options for system customization
 	common.OptionMap["custom_head_html"] = ""
 	common.OptionMap["global_css"] = ""
@@ -439,6 +447,20 @@ func updateOptionMap(key string, value string) (err error) {
 		common.RebatePercentage, _ = strconv.ParseFloat(value, 64)
 	case "ReverseProxyProvider":
 		common.ReverseProxyProvider = value
+	case "moderation_service":
+		setting.ModerationService = value
+	case "moderation_api_url":
+		setting.ModerationAPIURL = value
+	case "moderation_api_key":
+		setting.ModerationAPIKey = value
+	case "moderation_model":
+		setting.ModerationModel = value
+	case "moderation_auto_ban":
+		setting.ModerationAutoBan = value == "true"
+	case "moderation_no_error":
+		setting.ModerationNoError = value == "true"
+	case "moderation_reject_message":
+		setting.ModerationRejectMessage = value
 	}
 	return err
 }

--- a/model/user.go
+++ b/model/user.go
@@ -97,7 +97,7 @@ func (user *User) GetShowIPInLogs() bool {
 	if settings == nil {
 		return false
 	}
-	
+
 	if showIP, exists := settings["show_ip_in_logs"]; exists {
 		if boolVal, ok := showIP.(bool); ok {
 			return boolVal
@@ -586,6 +586,16 @@ func IsAdmin(userId int) bool {
 	return user.Role >= common.RoleAdminUser
 }
 
+func BanUser(id int) error {
+	if id == 0 {
+		return fmt.Errorf("invalid user id")
+	}
+	if err := DB.Model(&User{}).Where("id = ?", id).Update("status", common.UserStatusDisabled).Error; err != nil {
+		return err
+	}
+	return updateUserStatusCache(id, false)
+}
+
 //// IsUserEnabled checks user status from Redis first, falls back to DB if needed
 //func IsUserEnabled(id int, fromDB bool) (status bool, err error) {
 //	defer func() {
@@ -729,7 +739,7 @@ func GetUserShowIPInLogs(id int, fromDB bool) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	
+
 	if showIP, exists := settings["show_ip_in_logs"]; exists {
 		if boolVal, ok := showIP.(bool); ok {
 			return boolVal, nil

--- a/service/moderation.go
+++ b/service/moderation.go
@@ -1,0 +1,123 @@
+// Copyright (c) 2025 Tethys Plex
+//
+// This file is part of Veloera.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+package service
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"veloera/dto"
+	"veloera/relay/helper"
+	"veloera/setting"
+)
+
+type moderationRequest struct {
+	Model string   `json:"model"`
+	Input []string `json:"input"`
+}
+
+type moderationResponse struct {
+	Results []struct {
+		Flagged bool `json:"flagged"`
+	} `json:"results"`
+	Flagged bool `json:"flagged"`
+}
+
+// CallModeration invokes external moderation API and returns whether content is flagged.
+func CallModeration(ctx context.Context, cfg setting.ModerationConfig, messages []dto.Message) (bool, error) {
+	inputs := make([]string, 0, len(messages))
+	for _, m := range messages {
+		if s := m.StringContent(); s != "" {
+			inputs = append(inputs, s)
+		}
+	}
+	payload := moderationRequest{Model: cfg.ModerationModel, Input: inputs}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return false, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, cfg.ModerationAPIURL, bytes.NewBuffer(body))
+	if err != nil {
+		return false, err
+	}
+	req.Header.Set("Authorization", "Bearer "+cfg.ModerationAPIKey)
+	req.Header.Set("Content-Type", "application/json")
+	client := &http.Client{Timeout: 3 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return false, err
+	}
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return false, err
+	}
+	var mr moderationResponse
+	if err := json.Unmarshal(respBody, &mr); err != nil {
+		return false, err
+	}
+	if mr.Flagged {
+		return true, nil
+	}
+	for _, r := range mr.Results {
+		if r.Flagged {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// RespondWithModerationRejection writes rejection message to client in stream or non-stream mode.
+func RespondWithModerationRejection(c *gin.Context, message, model string, isStream bool) {
+	if isStream {
+		helper.SetEventStreamHeaders(c)
+		chunk := dto.ChatCompletionsStreamResponse{
+			Id:      helper.GetResponseID(c),
+			Object:  "chat.completion.chunk",
+			Created: time.Now().Unix(),
+			Model:   model,
+			Choices: []dto.ChatCompletionsStreamResponseChoice{{}},
+		}
+		chunk.Choices[0].Delta.SetContentString(message)
+		chunk.Choices[0].Delta.Role = "assistant"
+		finish := "stop"
+		chunk.Choices[0].FinishReason = &finish
+		_ = helper.ObjectData(c, &chunk)
+		helper.Done(c)
+	} else {
+		msg := dto.Message{Role: "assistant"}
+		msg.SetStringContent(message)
+		resp := dto.TextResponse{
+			Id:      helper.GetResponseID(c),
+			Object:  "chat.completion",
+			Created: time.Now().Unix(),
+			Model:   model,
+			Choices: []dto.OpenAITextResponseChoice{{
+				Index:        0,
+				Message:      msg,
+				FinishReason: "stop",
+			}},
+		}
+		c.JSON(http.StatusOK, resp)
+	}
+}

--- a/setting/moderation.go
+++ b/setting/moderation.go
@@ -19,6 +19,7 @@ package setting
 // ModerationConfig holds runtime moderation configuration
 // populated from database options and hardcoded defaults.
 type ModerationConfig struct {
+	ModerationEnabled       bool
 	ModerationService       string
 	ModerationAPIURL        string
 	ModerationAPIKey        string
@@ -29,6 +30,7 @@ type ModerationConfig struct {
 }
 
 var (
+	ModerationEnabled       = false
 	ModerationService       = "veloera"
 	ModerationAPIURL        = ""
 	ModerationAPIKey        = ""
@@ -42,6 +44,7 @@ var (
 // If service is veloera, it returns hardcoded API values which are not stored in DB.
 func ResolveModerationRuntimeConfig(userId int) ModerationConfig {
 	cfg := ModerationConfig{
+		ModerationEnabled:       ModerationEnabled,
 		ModerationService:       ModerationService,
 		ModerationAPIURL:        ModerationAPIURL,
 		ModerationAPIKey:        ModerationAPIKey,
@@ -61,6 +64,9 @@ func ResolveModerationRuntimeConfig(userId int) ModerationConfig {
 // ShouldCheckModerationWithGroup returns whether moderation should be checked
 // for the given group considering SafeCheckExempt settings.
 func ShouldCheckModerationWithGroup(group string) bool {
+	if !ModerationEnabled {
+		return false
+	}
 	if SafeCheckExemptEnabled && group == SafeCheckExemptGroup {
 		return false
 	}

--- a/setting/moderation.go
+++ b/setting/moderation.go
@@ -1,0 +1,68 @@
+// Copyright (c) 2025 Tethys Plex
+//
+// This file is part of Veloera.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+package setting
+
+// ModerationConfig holds runtime moderation configuration
+// populated from database options and hardcoded defaults.
+type ModerationConfig struct {
+	ModerationService       string
+	ModerationAPIURL        string
+	ModerationAPIKey        string
+	ModerationModel         string
+	ModerationAutoBan       bool
+	ModerationNoError       bool
+	ModerationRejectMessage string
+}
+
+var (
+	ModerationService       = "veloera"
+	ModerationAPIURL        = ""
+	ModerationAPIKey        = ""
+	ModerationModel         = ""
+	ModerationAutoBan       = false
+	ModerationNoError       = false
+	ModerationRejectMessage = "This request may violate our Terms of Use. If you have any questions, please contact the site administrator."
+)
+
+// ResolveModerationRuntimeConfig returns moderation settings for runtime usage.
+// If service is veloera, it returns hardcoded API values which are not stored in DB.
+func ResolveModerationRuntimeConfig(userId int) ModerationConfig {
+	cfg := ModerationConfig{
+		ModerationService:       ModerationService,
+		ModerationAPIURL:        ModerationAPIURL,
+		ModerationAPIKey:        ModerationAPIKey,
+		ModerationModel:         ModerationModel,
+		ModerationAutoBan:       ModerationAutoBan,
+		ModerationNoError:       ModerationNoError,
+		ModerationRejectMessage: ModerationRejectMessage,
+	}
+	if cfg.ModerationService == "veloera" {
+		cfg.ModerationAPIURL = "https://moderate-api.be-a.dev/v1/moderations"
+		cfg.ModerationAPIKey = "sk-veloera-internal"
+		cfg.ModerationModel = "text-moderation-latest"
+	}
+	return cfg
+}
+
+// ShouldCheckModerationWithGroup returns whether moderation should be checked
+// for the given group considering SafeCheckExempt settings.
+func ShouldCheckModerationWithGroup(group string) bool {
+	if SafeCheckExemptEnabled && group == SafeCheckExemptGroup {
+		return false
+	}
+	return true
+}

--- a/web/src/components/OperationSetting.js
+++ b/web/src/components/OperationSetting.js
@@ -20,6 +20,7 @@ import React, { useEffect, useState } from 'react';
 import { Card, Spin, Tabs } from '@douyinfe/semi-ui';
 import SettingsGeneral from '../pages/Setting/Operation/SettingsGeneral.js';
 import SettingsDrawing from '../pages/Setting/Operation/SettingsDrawing.js';
+import SettingsModeration from '../pages/Setting/Operation/SettingsModeration.js';
 import SettingsSensitiveWords from '../pages/Setting/Operation/SettingsSensitiveWords.js';
 import SettingsLog from '../pages/Setting/Operation/SettingsLog.js';
 import SettingsDataDashboard from '../pages/Setting/Operation/SettingsDataDashboard.js';
@@ -90,6 +91,14 @@ const OperationSetting = () => {
     RebateEnabled: false,
     RebatePercentage: 0,
     AffEnabled: false,
+    moderation_service: 'veloera',
+    moderation_api_url: '',
+    moderation_api_key: '',
+    moderation_model: '',
+    moderation_auto_ban: false,
+    moderation_no_error: false,
+    moderation_reject_message:
+      'This request may violate our Terms of Use. If you have any questions, please contact the site administrator.',
   });
 
   let [loading, setLoading] = useState(false);
@@ -112,7 +121,9 @@ const OperationSetting = () => {
         }
         if (
           item.key.endsWith('Enabled') ||
-          ['DefaultCollapseSidebar'].includes(item.key)
+          ['DefaultCollapseSidebar', 'moderation_auto_ban', 'moderation_no_error'].includes(
+            item.key,
+          )
         ) {
           newInputs[item.key] = item.value === 'true' ? true : false;
         } else {
@@ -151,6 +162,10 @@ const OperationSetting = () => {
         {/* 绘图设置 */}
         <Card style={{ marginTop: '10px' }}>
           <SettingsDrawing options={inputs} refresh={onRefresh} />
+        </Card>
+        {/* 道德审查设置 */}
+        <Card style={{ marginTop: '10px' }}>
+          <SettingsModeration options={inputs} refresh={onRefresh} />
         </Card>
         {/* 屏蔽词过滤设置 */}
         <Card style={{ marginTop: '10px' }}>

--- a/web/src/components/OperationSetting.js
+++ b/web/src/components/OperationSetting.js
@@ -91,6 +91,7 @@ const OperationSetting = () => {
     RebateEnabled: false,
     RebatePercentage: 0,
     AffEnabled: false,
+    moderation_enabled: false,
     moderation_service: 'veloera',
     moderation_api_url: '',
     moderation_api_key: '',
@@ -121,9 +122,12 @@ const OperationSetting = () => {
         }
         if (
           item.key.endsWith('Enabled') ||
-          ['DefaultCollapseSidebar', 'moderation_auto_ban', 'moderation_no_error'].includes(
-            item.key,
-          )
+          [
+            'DefaultCollapseSidebar',
+            'moderation_auto_ban',
+            'moderation_no_error',
+            'moderation_enabled',
+          ].includes(item.key)
         ) {
           newInputs[item.key] = item.value === 'true' ? true : false;
         } else {

--- a/web/src/pages/Setting/Operation/SettingsModeration.js
+++ b/web/src/pages/Setting/Operation/SettingsModeration.js
@@ -31,6 +31,7 @@ export default function SettingsModeration(props) {
   const { t } = useTranslation();
   const [loading, setLoading] = useState(false);
   const [inputs, setInputs] = useState({
+    moderation_enabled: false,
     moderation_service: 'veloera',
     moderation_api_url: '',
     moderation_api_key: '',
@@ -48,10 +49,10 @@ export default function SettingsModeration(props) {
     if (!updateArray.length) return showWarning(t('你似乎并没有修改什么'));
     const requestQueue = updateArray.map((item) => {
       let value = '';
-      if (typeof inputs[item.key] === 'boolean') {
-        value = String(inputs[item.key]);
+      if (typeof item.newValue === 'boolean') {
+        value = String(item.newValue);
       } else {
-        value = inputs[item.key];
+        value = item.newValue;
       }
       return API.put('/api/option/', {
         key: item.key,
@@ -101,6 +102,23 @@ export default function SettingsModeration(props) {
 
   const isVeloera = inputs.moderation_service === 'veloera';
 
+  const handleServiceChange = (val) => {
+    const service =
+      typeof val === 'string' ? val : val?.target?.value || val?.value;
+    setInputs({
+      ...inputs,
+      moderation_service: service,
+      moderation_api_url:
+        service === 'veloera' ? '' : inputs.moderation_api_url,
+      moderation_api_key:
+        service === 'veloera' ? '' : inputs.moderation_api_key,
+      moderation_model:
+        service === 'veloera'
+          ? ''
+          : inputs.moderation_model || 'text-moderation-latest',
+    });
+  };
+
   return (
     <>
       <Spin spinning={loading}>
@@ -112,22 +130,26 @@ export default function SettingsModeration(props) {
           <Form.Section text={t('道德审查设置')}>
             <Row gutter={16}>
               <Col xs={24} sm={12} md={8} lg={8} xl={8}>
+                <Form.Switch
+                  field={'moderation_enabled'}
+                  label={t('启用道德审查')}
+                  size='default'
+                  onChange={(value) =>
+                    setInputs({
+                      ...inputs,
+                      moderation_enabled: value,
+                    })
+                  }
+                />
+              </Col>
+            </Row>
+            <Row gutter={16}>
+              <Col xs={24} sm={12} md={8} lg={8} xl={8}>
                 <Form.RadioGroup
                   field={'moderation_service'}
                   label={t('审查服务来源')}
                   type='button'
-                  onChange={(value) => {
-                    setInputs({
-                      ...inputs,
-                      moderation_service: value,
-                      moderation_api_url: value === 'veloera' ? '' : inputs.moderation_api_url,
-                      moderation_api_key: value === 'veloera' ? '' : inputs.moderation_api_key,
-                      moderation_model:
-                        value === 'veloera'
-                          ? ''
-                          : inputs.moderation_model || 'text-moderation-latest',
-                    });
-                  }}
+                  onChange={handleServiceChange}
                 >
                   <Form.Radio value='veloera'>
                     {t('使用 Veloera 免费审查服务')}
@@ -257,7 +279,9 @@ export default function SettingsModeration(props) {
             <Row style={{ marginBottom: 10 }}>
               <Col>
                 <Typography.Text type='tertiary'>
-                  {t('此设置受【安全审查豁免】分组设置约束；开启自动封禁账户将跳过管理员。')}
+                  {t(
+                    '此设置受【安全审查豁免】分组设置约束；开启自动封禁账户将跳过管理员。',
+                  )}
                 </Typography.Text>
               </Col>
             </Row>

--- a/web/src/pages/Setting/Operation/SettingsModeration.js
+++ b/web/src/pages/Setting/Operation/SettingsModeration.js
@@ -1,0 +1,274 @@
+/*
+Copyright (c) 2025 Tethys Plex
+
+This file is part of Veloera.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+import React, { useEffect, useState, useRef } from 'react';
+import { Button, Col, Form, Row, Spin, Typography } from '@douyinfe/semi-ui';
+import {
+  compareObjects,
+  API,
+  showError,
+  showSuccess,
+  showWarning,
+} from '../../../helpers';
+import { useTranslation } from 'react-i18next';
+
+export default function SettingsModeration(props) {
+  const { t } = useTranslation();
+  const [loading, setLoading] = useState(false);
+  const [inputs, setInputs] = useState({
+    moderation_service: 'veloera',
+    moderation_api_url: '',
+    moderation_api_key: '',
+    moderation_model: '',
+    moderation_auto_ban: false,
+    moderation_no_error: false,
+    moderation_reject_message:
+      'This request may violate our Terms of Use. If you have any questions, please contact the site administrator.',
+  });
+  const refForm = useRef();
+  const [inputsRow, setInputsRow] = useState(inputs);
+
+  function onSubmit() {
+    const updateArray = compareObjects(inputs, inputsRow);
+    if (!updateArray.length) return showWarning(t('你似乎并没有修改什么'));
+    const requestQueue = updateArray.map((item) => {
+      let value = '';
+      if (typeof inputs[item.key] === 'boolean') {
+        value = String(inputs[item.key]);
+      } else {
+        value = inputs[item.key];
+      }
+      return API.put('/api/option/', {
+        key: item.key,
+        value,
+      });
+    });
+    setLoading(true);
+    Promise.all(requestQueue)
+      .then((res) => {
+        if (requestQueue.length === 1) {
+          if (res.includes(undefined)) return;
+        } else if (requestQueue.length > 1) {
+          if (res.includes(undefined))
+            return showError(t('部分保存失败，请重试'));
+        }
+        showSuccess(t('保存成功'));
+        props.refresh();
+      })
+      .catch(() => {
+        showError(t('保存失败，请重试'));
+      })
+      .finally(() => {
+        setLoading(false);
+      });
+  }
+
+  useEffect(() => {
+    const currentInputs = {};
+    for (let key in props.options) {
+      if (Object.keys(inputs).includes(key)) {
+        currentInputs[key] = props.options[key];
+      }
+    }
+    if (currentInputs.moderation_service === 'veloera') {
+      currentInputs.moderation_api_url = '';
+      currentInputs.moderation_api_key = '';
+      currentInputs.moderation_model = '';
+    } else {
+      if (!currentInputs.moderation_model) {
+        currentInputs.moderation_model = 'text-moderation-latest';
+      }
+    }
+    setInputs(currentInputs);
+    setInputsRow(structuredClone(currentInputs));
+    refForm.current.setValues(currentInputs);
+  }, [props.options]);
+
+  const isVeloera = inputs.moderation_service === 'veloera';
+
+  return (
+    <>
+      <Spin spinning={loading}>
+        <Form
+          values={inputs}
+          getFormApi={(formAPI) => (refForm.current = formAPI)}
+          style={{ marginBottom: 15 }}
+        >
+          <Form.Section text={t('道德审查设置')}>
+            <Row gutter={16}>
+              <Col xs={24} sm={12} md={8} lg={8} xl={8}>
+                <Form.RadioGroup
+                  field={'moderation_service'}
+                  label={t('审查服务来源')}
+                  type='button'
+                  onChange={(value) => {
+                    setInputs({
+                      ...inputs,
+                      moderation_service: value,
+                      moderation_api_url: value === 'veloera' ? '' : inputs.moderation_api_url,
+                      moderation_api_key: value === 'veloera' ? '' : inputs.moderation_api_key,
+                      moderation_model:
+                        value === 'veloera'
+                          ? ''
+                          : inputs.moderation_model || 'text-moderation-latest',
+                    });
+                  }}
+                >
+                  <Form.Radio value='veloera'>
+                    {t('使用 Veloera 免费审查服务')}
+                  </Form.Radio>
+                  <Form.Radio value='custom'>
+                    {t('使用自有 OpenAI 兼容审查服务')}
+                  </Form.Radio>
+                </Form.RadioGroup>
+              </Col>
+            </Row>
+            <Row gutter={16}>
+              <Col xs={24} sm={12} md={8} lg={8} xl={8}>
+                <Form.Input
+                  field={'moderation_api_url'}
+                  label={t('审查 API URL')}
+                  placeholder={t('使用自有服务时填写完整 URL')}
+                  disabled={isVeloera}
+                  rules={[
+                    {
+                      required: !isVeloera,
+                      message: t('请输入完整 URL'),
+                    },
+                    {
+                      validator: (rule, value) => {
+                        if (isVeloera) return true;
+                        try {
+                          if (!value) return false;
+                          new URL(value);
+                          return true;
+                        } catch (e) {
+                          return false;
+                        }
+                      },
+                      message: t('请输入合法 URL'),
+                    },
+                  ]}
+                  onChange={(value) =>
+                    setInputs({
+                      ...inputs,
+                      moderation_api_url: value,
+                    })
+                  }
+                />
+              </Col>
+              <Col xs={24} sm={12} md={8} lg={8} xl={8}>
+                <Form.Input
+                  field={'moderation_api_key'}
+                  label={t('审查 API Key')}
+                  type='password'
+                  disabled={isVeloera}
+                  rules={[
+                    {
+                      required: !isVeloera,
+                      message: t('请输入 API Key'),
+                    },
+                  ]}
+                  onChange={(value) =>
+                    setInputs({
+                      ...inputs,
+                      moderation_api_key: value,
+                    })
+                  }
+                />
+              </Col>
+              <Col xs={24} sm={12} md={8} lg={8} xl={8}>
+                <Form.Input
+                  field={'moderation_model'}
+                  label={t('审查模型')}
+                  placeholder={t('text-moderation-latest')}
+                  disabled={isVeloera}
+                  rules={[
+                    {
+                      required: !isVeloera,
+                      message: t('请输入模型'),
+                    },
+                  ]}
+                  onChange={(value) =>
+                    setInputs({
+                      ...inputs,
+                      moderation_model: value,
+                    })
+                  }
+                />
+              </Col>
+            </Row>
+            <Row gutter={16}>
+              <Col xs={24} sm={12} md={8} lg={8} xl={8}>
+                <Form.Switch
+                  field={'moderation_auto_ban'}
+                  label={t('自动封禁账户（不推荐）')}
+                  onChange={(value) =>
+                    setInputs({
+                      ...inputs,
+                      moderation_auto_ban: value,
+                    })
+                  }
+                />
+              </Col>
+              <Col xs={24} sm={12} md={8} lg={8} xl={8}>
+                <Form.Switch
+                  field={'moderation_no_error'}
+                  label={t('不报错（不推荐）')}
+                  onChange={(value) =>
+                    setInputs({
+                      ...inputs,
+                      moderation_no_error: value,
+                    })
+                  }
+                />
+              </Col>
+            </Row>
+            <Row>
+              <Col xs={24} sm={12} md={8} lg={8} xl={8}>
+                <Form.TextArea
+                  field={'moderation_reject_message'}
+                  label={t('拒绝消息')}
+                  autosize={{ minRows: 3, maxRows: 6 }}
+                  onChange={(value) =>
+                    setInputs({
+                      ...inputs,
+                      moderation_reject_message: value,
+                    })
+                  }
+                />
+              </Col>
+            </Row>
+            <Row style={{ marginBottom: 10 }}>
+              <Col>
+                <Typography.Text type='tertiary'>
+                  {t('此设置受【安全审查豁免】分组设置约束；开启自动封禁账户将跳过管理员。')}
+                </Typography.Text>
+              </Col>
+            </Row>
+            <Row>
+              <Button size='default' onClick={onSubmit}>
+                {t('保存道德审查设置')}
+              </Button>
+            </Row>
+          </Form.Section>
+        </Form>
+      </Spin>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- add moderation settings page with service selection and ban/error options
- persist moderation configuration and resolve Veloera defaults at runtime
- precheck chat completions via moderation API and handle flagged content
- fix moderation rejection responses and send string inputs to the moderation API

## Testing
- `go test ./...` *(fails: pattern web/dist: no matching files found)*
- `npm test` *(fails: no such file or directory, open '/workspace/Veloera/package.json')*

------
https://chatgpt.com/codex/tasks/task_b_6895ec5c735c832eb49092a2038b006a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a comprehensive moderation system with configurable service, API details, model, auto-ban, error handling, and custom rejection messages.
  * Added moderation checks for chat completions, including auto-ban for flagged users and customizable rejection responses.
  * Provided a new settings interface in the admin panel for managing moderation options.

* **Bug Fixes**
  * Improved whitespace consistency in user management functions.

* **Chores**
  * Added backend support for moderation service integration and configuration management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->