### PR TITLE
fix(relay): resolve model name prefix stripping regression

### DIFF
--- a/relay/common/relay_info.go
+++ b/relay/common/relay_info.go
@@ -178,20 +178,23 @@ func GenRelayInfo(c *gin.Context) *RelayInfo {
 	virtualModelOriginal := c.GetString("virtual_model_original")
 	virtualModelActual := c.GetString("virtual_model_actual")
 
-	// If we have a prefixed model, use it as the origin model name for display
-	// but use the unprefixed model name for the upstream
+	// Determine the display model name and upstream model name
+	displayModelName := originalModel
+	upstreamModelName := originalModel
+
+	// If we have a prefixed model, use it for display but keep the stripped version for upstream
 	if prefixedModel != "" {
-		originalModel = prefixedModel
+		displayModelName = prefixedModel
+		// upstreamModelName remains as originalModel (which has prefix stripped in distributor.go)
 	}
 
 	// Handle virtual model mapping for display and upstream names
-	upstreamModelName := originalModel
 	isVirtualModelMapped := false
-	
+
 	if virtualModelMapped && virtualModelOriginal != "" && virtualModelActual != "" {
 		// Virtual model mapping occurred
-		originalModel = virtualModelOriginal  // Display the original virtual model name
-		upstreamModelName = virtualModelActual // Use the actual mapped model
+		displayModelName = virtualModelOriginal // Display the original virtual model name
+		upstreamModelName = virtualModelActual  // Use the actual mapped model
 		isVirtualModelMapped = true
 	}
 
@@ -212,10 +215,10 @@ func GenRelayInfo(c *gin.Context) *RelayInfo {
 		TokenUnlimited:    tokenUnlimited,
 		StartTime:         startTime,
 		FirstResponseTime: startTime.Add(-time.Second),
-		OriginModelName:   originalModel,                 // Use the virtual model name or prefixed model for display
-		UpstreamModelName: upstreamModelName,            // Use the actual model name for upstream
+		OriginModelName:   displayModelName,  // Use the virtual model name or prefixed model for display
+		UpstreamModelName: upstreamModelName, // Use the actual model name for upstream
 		//RecodeModelName:   c.GetString("original_model"),
-		IsModelMapped:     isVirtualModelMapped,         // Mark if virtual model mapping occurred
+		IsModelMapped:     isVirtualModelMapped, // Mark if virtual model mapping occurred
 		ApiType:           apiType,
 		ApiVersion:        c.GetString("api_version"),
 		ApiKey:            strings.TrimPrefix(c.Request.Header.Get("Authorization"), "Bearer "),


### PR DESCRIPTION
Fix issue where model name prefixes (e.g., "google/") were being sent to upstream providers after global model mapping implementation in 4822abe.

The problem was in relay_info.go where the prefixed model name was incorrectly used for both display and upstream purposes. This caused requests like "google/gemini-pro" to be sent to upstream instead of the expected "gemini-pro", leading to request failures.

Changes:
  - Separate display model name from upstream model name in RelayInfo
  - Use prefixed model for display/logging but stripped model for upstream
  - Preserve prefix stripping logic that was bypassed by global mapping

Fixes regression introduced in commit 4822abe (global model mapping)

closes #170 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected model name display in the UI to show the intended model name for prefixed and virtual models, avoiding exposure of upstream routing names.
  * Ensured consistent labeling when virtual models are mapped, improving clarity without altering behavior.
  * Preserved routing and functionality; no changes to APIs or user workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->