### PR TITLE
fix(convert.go): fix Claude Code support

### DIFF
--- a/service/convert.go
+++ b/service/convert.go
@@ -146,7 +146,6 @@ func ClaudeToOpenAIRequest(claudeRequest dto.ClaudeRequest, info *relaycommon.Re
 
 					oaiToolMessage := dto.Message{
 						Role:       "tool",
-						Name:       &mediaMsg.Name,
 						ToolCallId: toolCallId,
 					}
 					//oaiToolMessage.SetStringContent(*mediaMsg.GetMediaContent().Text)

--- a/service/convert.go
+++ b/service/convert.go
@@ -268,6 +268,30 @@ func StreamResponseOpenAI2Claude(openAIResponse *dto.ChatCompletionsStreamRespon
 		if chosenChoice.FinishReason != nil && *chosenChoice.FinishReason != "" {
 			// should be done
 			info.FinishReason = *chosenChoice.FinishReason
+			info.Done = true
+			
+			// Handle tool call completion
+			if *chosenChoice.FinishReason == "tool_calls" || *chosenChoice.FinishReason == "function_call" {
+				// Send content_block_stop for tool call
+				claudeResponses = append(claudeResponses, generateStopBlock(info.ClaudeConvertInfo.Index))
+				
+				// Send message_delta with stop_reason
+				claudeResponses = append(claudeResponses, &dto.ClaudeResponse{
+					Type: "message_delta",
+					Usage: &dto.ClaudeUsage{
+						InputTokens:  info.PromptTokens,
+						OutputTokens: 0, // Will be updated later
+					},
+					Delta: &dto.ClaudeMediaMessage{
+						StopReason: common.GetPointer[string]("tool_use"),
+					},
+				})
+				
+				// Send message_stop
+				claudeResponses = append(claudeResponses, &dto.ClaudeResponse{
+					Type: "message_stop",
+				})
+			}
 			return claudeResponses
 		}
 		if info.Done {

--- a/service/convert.go
+++ b/service/convert.go
@@ -164,7 +164,7 @@ func ClaudeToOpenAIRequest(claudeRequest dto.ClaudeRequest, info *relaycommon.Re
 				openAIMessage.SetToolCalls(toolCalls)
 			}
 
-			if len(mediaMessages) > 0 && len(toolCalls) == 0 {
+			if len(mediaMessages) > 0 {
 				openAIMessage.SetMediaContent(mediaMessages)
 			}
 		}

--- a/service/convert.go
+++ b/service/convert.go
@@ -107,7 +107,7 @@ func ClaudeToOpenAIRequest(claudeRequest dto.ClaudeRequest, info *relaycommon.Re
 			}
 			contents := content
 			var toolCalls []dto.ToolCallRequest
-			mediaMessages := make([]dto.MediaContent, 0, len(contents))
+			mediaMessages := make([]dto.MediaContent, 0)
 
 			for _, mediaMsg := range contents {
 				switch mediaMsg.Type {
@@ -269,12 +269,12 @@ func StreamResponseOpenAI2Claude(openAIResponse *dto.ChatCompletionsStreamRespon
 			// should be done
 			info.FinishReason = *chosenChoice.FinishReason
 			info.Done = true
-			
+
 			// Handle tool call completion
 			if *chosenChoice.FinishReason == "tool_calls" || *chosenChoice.FinishReason == "function_call" {
 				// Send content_block_stop for tool call
 				claudeResponses = append(claudeResponses, generateStopBlock(info.ClaudeConvertInfo.Index))
-				
+
 				// Send message_delta with stop_reason
 				claudeResponses = append(claudeResponses, &dto.ClaudeResponse{
 					Type: "message_delta",
@@ -286,7 +286,7 @@ func StreamResponseOpenAI2Claude(openAIResponse *dto.ChatCompletionsStreamRespon
 						StopReason: common.GetPointer[string]("tool_use"),
 					},
 				})
-				
+
 				// Send message_stop
 				claudeResponses = append(claudeResponses, &dto.ClaudeResponse{
 					Type: "message_stop",


### PR DESCRIPTION
修复了Anthropic格式接口的若干兼容性问题：
- 去除多余的tool call message中的`Name`
- 在一个message消息体中同时存在text content和tool call的情况，会因为`mediaMessages`预留的空间过多（tool call的消息并不会append）导致`JSON.marshal`出错（转换成null）
- tool call结束时需要额外补充stop reason的数据包