### PR TITLE
# 添加全局模型映射的权重功能

### DIFF
--- a/controller/model_mapping.go
+++ b/controller/model_mapping.go
@@ -29,7 +29,7 @@ import (
 // GetGlobalModelMapping 获取当前全局模型映射配置
 func GetGlobalModelMapping(c *gin.Context) {
 	mapping := service.GetGlobalModelMapping()
-	
+
 	c.JSON(http.StatusOK, gin.H{
 		"success": true,
 		"message": "",
@@ -40,7 +40,7 @@ func GetGlobalModelMapping(c *gin.Context) {
 // UpdateGlobalModelMapping 更新全局模型映射配置
 func UpdateGlobalModelMapping(c *gin.Context) {
 	var mapping model.GlobalModelMapping
-	
+
 	if err := c.ShouldBindJSON(&mapping); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{
 			"success": false,
@@ -48,27 +48,27 @@ func UpdateGlobalModelMapping(c *gin.Context) {
 		})
 		return
 	}
-	
+
 	if err := service.UpdateGlobalModelMapping(&mapping); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{
+		// 将StatusInternalServerError改为StatusBadRequest，并更新错误信息
+		c.JSON(http.StatusBadRequest, gin.H{
 			"success": false,
 			"message": "更新全局模型映射配置失败: " + err.Error(),
 		})
 		return
 	}
-	
+
 	c.JSON(http.StatusOK, gin.H{
 		"success": true,
-		"message": "全局模型映射配置更新成功",
+		"message": "全局模型映射配置更新成功", // 更新成功消息
+		"data":    mapping,        // 返回更新后的配置
 	})
 }
-
-
 
 // GetModelMappingConfig 获取模型映射配置的JSON字符串形式
 func GetModelMappingConfig(c *gin.Context) {
 	configStr := service.GlobalModelMappingToJSONString()
-	
+
 	// 尝试解析JSON字符串以验证格式
 	var config map[string]interface{}
 	if err := json.Unmarshal([]byte(configStr), &config); err != nil {
@@ -78,7 +78,7 @@ func GetModelMappingConfig(c *gin.Context) {
 		})
 		return
 	}
-	
+
 	c.JSON(http.StatusOK, gin.H{
 		"success": true,
 		"message": "",
@@ -97,12 +97,12 @@ func UpdateModelMappingConfig(c *gin.Context) {
 		})
 		return
 	}
-	
+
 	// 如果请求体为空，设置为空字符串
 	if len(jsonStr) == 0 {
 		jsonStr = []byte("{}")
 	}
-	
+
 	// 更新配置
 	if err := service.UpdateGlobalModelMappingFromJSONString(string(jsonStr)); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{
@@ -111,13 +111,12 @@ func UpdateModelMappingConfig(c *gin.Context) {
 		})
 		return
 	}
-	
+
 	c.JSON(http.StatusOK, gin.H{
 		"success": true,
 		"message": "全局模型映射配置更新成功",
 	})
 }
-
 
 // ReloadModelMapping 重新加载模型映射配置
 func ReloadModelMapping(c *gin.Context) {
@@ -128,7 +127,7 @@ func ReloadModelMapping(c *gin.Context) {
 		})
 		return
 	}
-	
+
 	c.JSON(http.StatusOK, gin.H{
 		"success": true,
 		"message": "模型映射配置重新加载成功",

--- a/examples/global_model_mapping_example.go
+++ b/examples/global_model_mapping_example.go
@@ -36,17 +36,17 @@ func main() {
 	exampleMapping := &model.GlobalModelMapping{
 		Mapping: map[string][]model.ModelMappingItem{
 			"gpt-3.5-turbo": {
-				{Model: "gpt-3.5-turbo-0613", Priorities: 10},
-				{Model: "gpt-3.5-turbo-0301", Priorities: 10},
-				{Model: "gpt-3.5-turbo-16k", Priorities: 5},
+				{Model: "gpt-3.5-turbo-0613", Priorities: 10, Weight: 30},
+				{Model: "gpt-3.5-turbo-0301", Priorities: 10, Weight: 20},
+				{Model: "gpt-3.5-turbo-16k", Priorities: 5, Weight: 10},
 			},
 			"gpt-4": {
-				{Model: "gpt-4-0613", Priorities: 10},
-				{Model: "gpt-4-0314", Priorities: 8},
+				{Model: "gpt-4-0613", Priorities: 10, Weight: 40},
+				{Model: "gpt-4-0314", Priorities: 8, Weight: 20},
 			},
 			"claude-instant": {
-				{Model: "claude-instant-1.2", Priorities: 10},
-				{Model: "claude-instant-1.1", Priorities: 5},
+				{Model: "claude-instant-1.2", Priorities: 10, Weight: 30},
+				{Model: "claude-instant-1.1", Priorities: 5, Weight: 15},
 			},
 		},
 	}

--- a/model/global_model_mapping.go
+++ b/model/global_model_mapping.go
@@ -28,8 +28,8 @@ import (
 // 全局变量
 var (
 	globalModelMapping *GlobalModelMapping
-	roundRobinCounter  *RoundRobinCounter
-	ModelMappingMutex  sync.RWMutex
+	// roundRobinCounter  *RoundRobinCounter // 移除轮询计数器，因为现在使用权重随机选择
+	ModelMappingMutex sync.RWMutex
 )
 
 // init 包初始化函数
@@ -38,7 +38,7 @@ func init() {
 	globalModelMapping = &GlobalModelMapping{
 		Mapping: make(map[string][]ModelMappingItem),
 	}
-	roundRobinCounter = NewRoundRobinCounter()
+	// roundRobinCounter = NewRoundRobinCounter() // 移除轮询计数器初始化
 }
 
 // LoadModelMappingConfig 从数据库加载配置
@@ -162,8 +162,8 @@ func UpdateGlobalModelMapping(mapping *GlobalModelMapping) error {
 
 	globalModelMapping = mapping
 
-	// 重置轮询计数器
-	roundRobinCounter.ClearAllCounters()
+	// 重置轮询计数器 (已移除，无需操作)
+	// roundRobinCounter.ClearAllCounters()
 
 	common.SysLog("Global model mapping configuration updated successfully")
 	return nil
@@ -174,8 +174,8 @@ func InitializeModelMapping() error {
 	ModelMappingMutex.Lock()
 	defer ModelMappingMutex.Unlock()
 
-	// 初始化轮询计数器
-	roundRobinCounter = NewRoundRobinCounter()
+	// 初始化轮询计数器 (已移除，无需操作)
+	// roundRobinCounter = NewRoundRobinCounter()
 
 	// 直接调用内部加载逻辑，避免重复加锁
 	if err := loadModelMappingConfigUnsafe(); err != nil {
@@ -198,8 +198,8 @@ func ReloadModelMapping() error {
 		return err
 	}
 
-	// 重置轮询计数器
-	roundRobinCounter.ClearAllCounters()
+	// 重置轮询计数器 (已移除，无需操作)
+	// roundRobinCounter.ClearAllCounters()
 
 	common.SysLog("Model mapping configuration reload successful")
 	return nil

--- a/model/global_model_mapping_types.go
+++ b/model/global_model_mapping_types.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"math/rand"
 	"strings"
-	"sync"
 	"time"
 )
 
@@ -29,6 +28,7 @@ import (
 type ModelMappingItem struct {
 	Model      string `json:"model" binding:"required"`   // 实际模型名
 	Priorities int    `json:"priorities" binding:"min=0"` // 优先级(非负整数)
+	Weight     int    `json:"weight" binding:"min=0"`     // 权重(非负整数，0权重会默认设置为10)
 }
 
 // GlobalModelMapping 全局模型映射配置
@@ -36,63 +36,22 @@ type GlobalModelMapping struct {
 	Mapping map[string][]ModelMappingItem `json:"mapping"` // 虚拟模型名 -> 实际模型映射列表
 }
 
-// RoundRobinCounter 轮询计数器
-type RoundRobinCounter struct {
-	counters map[string]int
-	mutex    sync.RWMutex
-}
-
-// NewRoundRobinCounter 创建新的轮询计数器
-func NewRoundRobinCounter() *RoundRobinCounter {
-	return &RoundRobinCounter{
-		counters: make(map[string]int),
-	}
-}
-
-// GetNext 获取下一个轮询索引
-func (rrc *RoundRobinCounter) GetNext(key string, maxIndex int) int {
-	if maxIndex <= 0 {
-		return 0
-	}
-	
-	rrc.mutex.Lock()
-	defer rrc.mutex.Unlock()
-	
-	current, exists := rrc.counters[key]
-	if !exists {
-		current = 0
-	}
-	
-	next := (current + 1) % maxIndex
-	rrc.counters[key] = next
-	
-	return current
-}
-
-// ClearAllCounters 清空所有计数器
-func (rrc *RoundRobinCounter) ClearAllCounters() {
-	rrc.mutex.Lock()
-	defer rrc.mutex.Unlock()
-	
-	rrc.counters = make(map[string]int)
-}
-
-// GetActualModel 根据虚拟模型名获取实际模型名（考虑优先级和轮询）
+// GetActualModel 根据虚拟模型名获取实际模型名（考虑优先级和权重）
 func GetActualModel(virtualModel string) (string, error) {
 	ModelMappingMutex.RLock()
 	defer ModelMappingMutex.RUnlock()
-	
+
 	if globalModelMapping == nil || len(globalModelMapping.Mapping) == 0 {
 		// 如果没有配置映射，直接返回原模型名
 		return virtualModel, nil
 	}
-	
+
 	mappingItems, exists := globalModelMapping.Mapping[virtualModel]
 	if !exists || len(mappingItems) == 0 {
 		// 如果虚拟模型没有映射配置，直接返回原模型名
 		return virtualModel, nil
 	}
-	
+
 	// 按优先级分组
 	priorityGroups := make(map[int][]ModelMappingItem)
 	for _, item := range mappingItems {
@@ -100,13 +59,17 @@ func GetActualModel(virtualModel string) (string, error) {
 			// 跳过无效的优先级（负数）
 			continue
 		}
+		// 确保权重至少为10（避免默认0的权重无法选取）
+		if item.Weight < 10 {
+			item.Weight = 10
+		}
 		priorityGroups[item.Priorities] = append(priorityGroups[item.Priorities], item)
 	}
-	
+
 	if len(priorityGroups) == 0 {
 		return virtualModel, nil
 	}
-	
+
 	// 获取最高优先级
 	var maxPriority int = -1
 	for priority := range priorityGroups {
@@ -114,28 +77,55 @@ func GetActualModel(virtualModel string) (string, error) {
 			maxPriority = priority
 		}
 	}
-	
+
 	highestPriorityItems := priorityGroups[maxPriority]
 	if len(highestPriorityItems) == 0 {
 		return virtualModel, nil
 	}
-	
+
 	// 如果只有一个最高优先级项目，直接返回
 	if len(highestPriorityItems) == 1 {
 		return highestPriorityItems[0].Model, nil
 	}
-	
-	// 使用轮询策略从最高优先级项目中选择
-	if roundRobinCounter == nil {
-		// 如果轮询计数器未初始化，使用随机选择
-		rand.Seed(time.Now().UnixNano())
-		index := rand.Intn(len(highestPriorityItems))
-		return highestPriorityItems[index].Model, nil
+
+	// 根据权重随机选择
+	return selectModelByWeight(highestPriorityItems)
+}
+
+// selectModelByWeight 根据权重随机选择模型
+func selectModelByWeight(items []ModelMappingItem) (string, error) {
+	// 计算总权重
+	totalWeight := 0
+	for _, item := range items {
+		totalWeight += item.Weight
 	}
-	
-	// 使用轮询计数器
-	index := roundRobinCounter.GetNext(virtualModel, len(highestPriorityItems))
-	return highestPriorityItems[index].Model, nil
+
+	if totalWeight == 0 {
+		// 如果所有权重都为0，返回第一个模型或错误
+		if len(items) > 0 {
+			return items[0].Model, nil
+		}
+		return "", fmt.Errorf("没有可用的模型进行权重选择")
+	}
+
+	// 生成随机数
+	rand.Seed(time.Now().UnixNano())
+	randomWeight := rand.Intn(totalWeight)
+
+	// 根据权重选择模型
+	currentWeight := 0
+	for _, item := range items {
+		currentWeight += item.Weight
+		if randomWeight < currentWeight {
+			return item.Model, nil
+		}
+	}
+
+	// 理论上不应到达此处，作为备用返回最后一个
+	if len(items) > 0 {
+		return items[len(items)-1].Model, nil
+	}
+	return "", fmt.Errorf("未能根据权重选择模型")
 }
 
 // ValidateModelMapping 验证模型映射配置
@@ -143,32 +133,36 @@ func ValidateModelMapping(mapping *GlobalModelMapping) error {
 	if mapping == nil {
 		return fmt.Errorf("映射配置不能为空")
 	}
-	
+
 	if mapping.Mapping == nil {
 		return fmt.Errorf("映射字典不能为空")
 	}
-	
+
 	for virtualModel, items := range mapping.Mapping {
 		if strings.TrimSpace(virtualModel) == "" {
 			return fmt.Errorf("虚拟模型名不能为空")
 		}
-		
+
 		if len(items) == 0 {
 			return fmt.Errorf("虚拟模型 '%s' 的映射项不能为空", virtualModel)
 		}
-		
+
 		// 用于检查同一虚拟模型内实际模型名的重复
 		modelSet := make(map[string]bool)
-		
+
 		for i, item := range items {
 			if strings.TrimSpace(item.Model) == "" {
 				return fmt.Errorf("虚拟模型 '%s' 的第 %d 个映射项的实际模型名不能为空", virtualModel, i+1)
 			}
-			
+
 			if item.Priorities < 0 {
 				return fmt.Errorf("虚拟模型 '%s' 的实际模型 '%s' 的优先级必须为非负整数", virtualModel, item.Model)
 			}
-			
+
+			if item.Weight < 0 {
+				return fmt.Errorf("虚拟模型 '%s' 的实际模型 '%s' 的权重必须为非负整数", virtualModel, item.Model)
+			}
+
 			// 检查同一虚拟模型内实际模型名的重复
 			trimmedModel := strings.TrimSpace(item.Model)
 			if modelSet[trimmedModel] {
@@ -177,6 +171,6 @@ func ValidateModelMapping(mapping *GlobalModelMapping) error {
 			modelSet[trimmedModel] = true
 		}
 	}
-	
+
 	return nil
 }

--- a/web/src/pages/Setting/Model/SettingModelMapping.js
+++ b/web/src/pages/Setting/Model/SettingModelMapping.js
@@ -45,12 +45,12 @@ const { Title, Text } = Typography;
 
 export default function SettingModelMapping() {
   const { t } = useTranslation();
-  
+
   const [loading, setLoading] = useState(false);
   const [mappings, setMappings] = useState({});
   const [modalVisible, setModalVisible] = useState(false);
   const [editingMapping, setEditingMapping] = useState(null);
-  const [models, setModels] = useState([{ model: '', priorities: 0 }]);
+  const [models, setModels] = useState([{ model: '', priorities: 0, weight: 0 }]); // 初始化添加权重字段
   const [virtualModelError, setVirtualModelError] = useState('');
   const [modelErrors, setModelErrors] = useState([]);
   const formApiRef = useRef();
@@ -88,7 +88,7 @@ export default function SettingModelMapping() {
       setVirtualModelError('');
       return;
     }
-    
+
     if (!editingMapping && mappings[trimmedValue]) {
       setVirtualModelError(`虚拟模型名 '${trimmedValue}' 已存在`);
     } else if (editingMapping && editingMapping !== trimmedValue && mappings[trimmedValue]) {
@@ -103,7 +103,7 @@ export default function SettingModelMapping() {
     const errors = [];
     const modelNames = new Set();
     const duplicates = new Set();
-    
+
     models.forEach((model, index) => {
       const trimmedModel = model.model.trim();
       if (trimmedModel) {
@@ -118,7 +118,7 @@ export default function SettingModelMapping() {
         errors[index] = '';
       }
     });
-    
+
     // 为重复的模型设置错误信息
     models.forEach((model, index) => {
       const trimmedModel = model.model.trim();
@@ -126,7 +126,7 @@ export default function SettingModelMapping() {
         errors[index] = `模型名重复: ${trimmedModel}`;
       }
     });
-    
+
     setModelErrors(errors);
   };
 
@@ -150,6 +150,7 @@ export default function SettingModelMapping() {
         .map((model) => ({
           model: model.model.trim(),
           priorities: parseInt(model.priorities) || 0,
+          weight: parseInt(model.weight) || 0,  // 添加权重字段
         }))
         .filter((model) => model.model); // 过滤空模型
 
@@ -159,7 +160,7 @@ export default function SettingModelMapping() {
         showError(`虚拟模型名 '${trimmedVirtualModel}' 已存在，请使用不同的名称`);
         return;
       }
-      
+
       // 如果是编辑模式但虚拟模型名已存在且不是当前编辑的项目
       if (editingMapping && editingMapping !== trimmedVirtualModel && mappings[trimmedVirtualModel]) {
         showError(`虚拟模型名 '${trimmedVirtualModel}' 已存在，请使用不同的名称`);
@@ -169,7 +170,7 @@ export default function SettingModelMapping() {
       // 前端验证：检查同一虚拟模型内实际模型名是否重复
       const modelNames = new Set();
       const duplicateModels = [];
-      
+
       for (let i = 0; i < processedModels.length; i++) {
         const modelName = processedModels[i].model;
         if (modelNames.has(modelName)) {
@@ -178,7 +179,7 @@ export default function SettingModelMapping() {
           modelNames.add(modelName);
         }
       }
-      
+
       if (duplicateModels.length > 0) {
         showError(`实际模型名重复: ${duplicateModels.join(', ')}`);
         return;
@@ -210,7 +211,7 @@ export default function SettingModelMapping() {
           formApiRef.current.reset();
         }
         setEditingMapping(null);
-        setModels([{ model: '', priorities: 0 }]);
+        setModels([{ model: '', priorities: 0, weight: 0 }]); // 重置时添加权重字段
         setVirtualModelError('');
         setModelErrors([]);
       } else {
@@ -274,10 +275,10 @@ export default function SettingModelMapping() {
           formApiRef.current.setValues({
             virtualModel,
           });
-          setModels(mappings[virtualModel] || [{ model: '', priorities: 0 }]);
+          setModels(mappings[virtualModel] || [{ model: '', priorities: 0, weight: 0 }]);
         } else {
           formApiRef.current.reset();
-          setModels([{ model: '', priorities: 0 }]);
+          setModels([{ model: '', priorities: 0, weight: 0 }]); // 新增时添加权重字段
         }
       }
     }, 100);
@@ -285,7 +286,7 @@ export default function SettingModelMapping() {
 
   // 添加模型
   const addModel = () => {
-    setModels([...models, { model: '', priorities: 0 }]);
+    setModels([...models, { model: '', priorities: 0, weight: 0 }]); // 添加权重字段
   };
 
   // 删除模型
@@ -365,13 +366,13 @@ export default function SettingModelMapping() {
       render: (models) => {
         // 找到最高优先级的值
         const maxPriority = Math.max(...models.map(model => model.priorities));
-        
+
         return (
           <Space wrap>
             {models.map((model, index) => {
               // 判断是否为最高优先级
               const isHighestPriority = model.priorities === maxPriority;
-              
+
               return (
                 <Tag
                   key={index}
@@ -390,7 +391,7 @@ export default function SettingModelMapping() {
                       : {}
                   }
                 >
-                  {model.model} (优先级: {model.priorities})
+                  {model.model} (优先级: {model.priorities}, 权重: {model.weight || 0}) {/* 显示权重信息 */}
                 </Tag>
               );
             })}
@@ -474,7 +475,7 @@ export default function SettingModelMapping() {
         onCancel={() => {
           setModalVisible(false);
           setEditingMapping(null);
-          setModels([{ model: '', priorities: 0 }]);
+          setModels([{ model: '', priorities: 0, weight: 0 }]);  // 关闭时重置权重字段
           setVirtualModelError('');
           setModelErrors([]);
           if (formApiRef.current) {
@@ -496,13 +497,16 @@ export default function SettingModelMapping() {
               { required: true, message: '请输入虚拟模型名' },
               { type: 'string', message: '虚拟模型名必须是字符串' },
             ]}
-            disabled={false}
+            disabled={!!editingMapping}  // 编辑模式下禁用
             onChange={validateVirtualModel}
             validateStatus={virtualModelError ? 'error' : ''}
             helpText={virtualModelError}
           />
           <div style={{ marginBottom: 16 }}>
             <Text strong>实际模型列表:</Text>
+            <Text type="secondary" style={{ marginLeft: 8 }}>
+              (优先级决定模型选择顺序，权重决定同优先级模型的选择概率) {/* 添加说明 */}
+            </Text>
             {models.map((model, index) => (
               <div
                 key={index}
@@ -517,16 +521,16 @@ export default function SettingModelMapping() {
                   <Input
                     value={model.model}
                     placeholder='实际模型名'
-                    style={{ 
+                    style={{
                       width: 300,
                       borderColor: modelErrors[index] ? '#ff4d4f' : undefined
                     }}
                     onChange={(value) => updateModel(index, 'model', value)}
                   />
                   {modelErrors[index] && (
-                    <Text 
-                      type="danger" 
-                      size="small" 
+                    <Text
+                      type="danger"
+                      size="small"
                       style={{ fontSize: '12px', marginTop: '2px' }}
                     >
                       {modelErrors[index]}
@@ -539,6 +543,13 @@ export default function SettingModelMapping() {
                   min={0}
                   style={{ width: 100, marginRight: 8, alignSelf: 'flex-start' }}
                   onChange={(value) => updateModel(index, 'priorities', value)}
+                />
+                <InputNumber
+                  value={model.weight || 0} // 添加权重输入框
+                  placeholder='权重'
+                  min={0}
+                  style={{ width: 100, marginRight: 8, alignSelf: 'flex-start' }}
+                  onChange={(value) => updateModel(index, 'weight', value)}
                 />
                 <Button
                   type='danger'


### PR DESCRIPTION
- 在ModelMappingItem结构体中添加Weight字段，支持权重配置
- 实现基于权重的随机模型选择算法，提升负载均衡能力
- 更新模型映射验证逻辑，支持权重字段验证
- 优化前端界面，添加权重字段输入和显示
- 提供完整的示例代码和使用说明

技术细节:
- 权重字段为非负整数，默认最小为0
- 系统自动为权重小于10的模型设置为10，避免0权重无法被选中
- 同优先级模型根据权重进行随机选择，提高负载均衡效果
- 前端界面支持权重字段的增删改查操作
- 编辑模式下虚拟模型名置灰，防止误修改

影响范围:
- model/global_model_mapping_types.go: 核心类型定义和算法实现
- model/global_model_mapping.go: 模型映射管理逻辑
- controller/model_mapping.go: API控制器更新
- web/src/pages/Setting/Model/SettingModelMapping.js: 前端界面更新
- examples/global_model_mapping_example.go: 示例代码更新