### PR TITLE
feat: 支持订阅额度与普通额度合并消费和退款处理 (subscription_quota_support)

### DIFF
--- a/relay/common/relay_info.go
+++ b/relay/common/relay_info.go
@@ -80,33 +80,35 @@ type RelayInfo struct {
 	UpstreamModelName string
 	OriginModelName   string
 	//RecodeModelName      string
-	RequestURLPath       string
-	ApiVersion           string
-	PromptTokens         int
-	ApiKey               string
-	Organization         string
-	BaseUrl              string
-	SupportStreamOptions bool
-	ShouldIncludeUsage   bool
-	IsModelMapped        bool
-	ClientWs             *websocket.Conn
-	TargetWs             *websocket.Conn
-	InputAudioFormat     string
-	OutputAudioFormat    string
-	RealtimeTools        []dto.RealTimeTool
-	IsFirstRequest       bool
-	AudioUsage           bool
-	ReasoningEffort      string
-	ChannelSetting       map[string]interface{}
-	ParamOverride        map[string]interface{}
-	UserSetting          map[string]interface{}
-	UserEmail            string
-	UserQuota            int
-	RelayFormat          string
-	SendResponseCount    int
-	ChannelCreateTime    int64
-	PromptMessages       interface{}            // 保存请求的消息内容
-	Other                map[string]interface{} // 用于存储额外信息，如输入输出内容
+	RequestURLPath            string
+	ApiVersion                string
+	PromptTokens              int
+	ApiKey                    string
+	Organization              string
+	BaseUrl                   string
+	SupportStreamOptions      bool
+	ShouldIncludeUsage        bool
+	IsModelMapped             bool
+	ClientWs                  *websocket.Conn
+	TargetWs                  *websocket.Conn
+	InputAudioFormat          string
+	OutputAudioFormat         string
+	RealtimeTools             []dto.RealTimeTool
+	IsFirstRequest            bool
+	AudioUsage                bool
+	ReasoningEffort           string
+	ChannelSetting            map[string]interface{}
+	ParamOverride             map[string]interface{}
+	UserSetting               map[string]interface{}
+	UserEmail                 string
+	UserQuota                 int
+	ConsumedSubscriptionQuota int
+	ConsumedQuota             int
+	RelayFormat               string
+	SendResponseCount         int
+	ChannelCreateTime         int64
+	PromptMessages            interface{}            // 保存请求的消息内容
+	Other                     map[string]interface{} // 用于存储额外信息，如输入输出内容
 	ThinkingContentInfo
 	*ClaudeConvertInfo
 	*RerankerInfo
@@ -266,6 +268,30 @@ func GenRelayInfo(c *gin.Context) *RelayInfo {
 
 func (info *RelayInfo) SetPromptTokens(promptTokens int) {
 	info.PromptTokens = promptTokens
+}
+
+func (info *RelayInfo) TrackConsumedQuota(subscriptionUsed, quotaUsed int) {
+	if subscriptionUsed > 0 {
+		info.ConsumedSubscriptionQuota += subscriptionUsed
+	}
+	if quotaUsed > 0 {
+		info.ConsumedQuota += quotaUsed
+	}
+}
+
+func (info *RelayInfo) TrackRefundedQuota(subscriptionRefund, quotaRefund int) {
+	if subscriptionRefund > 0 {
+		info.ConsumedSubscriptionQuota -= subscriptionRefund
+		if info.ConsumedSubscriptionQuota < 0 {
+			info.ConsumedSubscriptionQuota = 0
+		}
+	}
+	if quotaRefund > 0 {
+		info.ConsumedQuota -= quotaRefund
+		if info.ConsumedQuota < 0 {
+			info.ConsumedQuota = 0
+		}
+	}
 }
 
 func (info *RelayInfo) SetIsStream(isStream bool) {

--- a/relay/relay-image.go
+++ b/relay/relay-image.go
@@ -114,10 +114,11 @@ func ImageHelper(c *gin.Context) *dto.OpenAIErrorWithStatusCode {
 		priceData.ModelPrice = 0.0025 * priceData.ModelRatio
 	}
 
-	userQuota, err := model.GetUserQuota(relayInfo.UserId, false)
+	userBalance, err := model.GetUserQuotaBalance(relayInfo.UserId, false)
 	if err != nil {
 		return service.OpenAIErrorWrapperLocal(err, "get_user_quota_failed", http.StatusInternalServerError)
 	}
+	totalQuota := userBalance.Total()
 
 	sizeRatio := 1.0
 	// Size
@@ -142,8 +143,8 @@ func ImageHelper(c *gin.Context) *dto.OpenAIErrorWithStatusCode {
 	priceData.ModelPrice *= sizeRatio * qualityRatio * float64(imageRequest.N)
 	quota := int(priceData.ModelPrice * priceData.GroupRatio * common.QuotaPerUnit)
 
-	if userQuota-quota < 0 {
-		return service.OpenAIErrorWrapperLocal(fmt.Errorf("image pre-consumed quota failed, user quota: %s, need quota: %s", common.FormatQuota(userQuota), common.FormatQuota(quota)), "insufficient_user_quota", http.StatusForbidden)
+	if totalQuota-quota < 0 {
+		return service.OpenAIErrorWrapperLocal(fmt.Errorf("image pre-consumed quota failed, user quota: %s, need quota: %s", common.FormatQuota(totalQuota), common.FormatQuota(quota)), "insufficient_user_quota", http.StatusForbidden)
 	}
 
 	adaptor := GetAdaptor(relayInfo.ApiType)
@@ -203,6 +204,6 @@ func ImageHelper(c *gin.Context) *dto.OpenAIErrorWithStatusCode {
 	logContent := fmt.Sprintf("大小 %s, 品质 %s", imageRequest.Size, quality)
 	// 标记响应已写入，用于空回复检测
 	c.Set("response_written", true)
-	postConsumeQuota(c, relayInfo, usage, 0, userQuota, priceData, logContent)
+	postConsumeQuota(c, relayInfo, usage, 0, totalQuota, priceData, logContent)
 	return nil
 }

--- a/relay/relay-image.go
+++ b/relay/relay-image.go
@@ -115,6 +115,9 @@ func ImageHelper(c *gin.Context) *dto.OpenAIErrorWithStatusCode {
 	}
 
 	userQuota, err := model.GetUserQuota(relayInfo.UserId, false)
+	if err != nil {
+		return service.OpenAIErrorWrapperLocal(err, "get_user_quota_failed", http.StatusInternalServerError)
+	}
 
 	sizeRatio := 1.0
 	// Size

--- a/relay/relay-text.go
+++ b/relay/relay-text.go
@@ -381,18 +381,19 @@ func checkRequestSensitive(textRequest *dto.GeneralOpenAIRequest, info *relaycom
 
 // 预扣费并返回用户剩余配额
 func preConsumeQuota(c *gin.Context, preConsumedQuota int, relayInfo *relaycommon.RelayInfo) (int, int, *dto.OpenAIErrorWithStatusCode) {
-	userQuota, err := model.GetUserQuota(relayInfo.UserId, false)
+	userBalance, err := model.GetUserQuotaBalance(relayInfo.UserId, false)
 	if err != nil {
 		return 0, 0, service.OpenAIErrorWrapperLocal(err, "get_user_quota_failed", http.StatusInternalServerError)
 	}
-	if userQuota <= 0 {
+	totalQuota := userBalance.Total()
+	if totalQuota <= 0 {
 		return 0, 0, service.OpenAIErrorWrapperLocal(errors.New("user quota is not enough"), "insufficient_user_quota", http.StatusForbidden)
 	}
-	if userQuota-preConsumedQuota < 0 {
-		return 0, 0, service.OpenAIErrorWrapperLocal(fmt.Errorf("chat pre-consumed quota failed, user quota: %s, need quota: %s", common.FormatQuota(userQuota), common.FormatQuota(preConsumedQuota)), "insufficient_user_quota", http.StatusForbidden)
+	if totalQuota-preConsumedQuota < 0 {
+		return 0, 0, service.OpenAIErrorWrapperLocal(fmt.Errorf("chat pre-consumed quota failed, user quota: %s, need quota: %s", common.FormatQuota(totalQuota), common.FormatQuota(preConsumedQuota)), "insufficient_user_quota", http.StatusForbidden)
 	}
-	relayInfo.UserQuota = userQuota
-	if userQuota > 100*preConsumedQuota {
+	relayInfo.UserQuota = totalQuota
+	if totalQuota > 100*preConsumedQuota {
 		// 用户额度充足，判断令牌额度是否充足
 		if !relayInfo.TokenUnlimited {
 			// 非无限令牌，判断令牌额度是否充足
@@ -400,13 +401,13 @@ func preConsumeQuota(c *gin.Context, preConsumedQuota int, relayInfo *relaycommo
 			if tokenQuota > 100*preConsumedQuota {
 				// 令牌额度充足，信任令牌
 				preConsumedQuota = 0
-				common.LogInfo(c, fmt.Sprintf("user %d quota %s and token %d quota %d are enough, trusted and no need to pre-consume", relayInfo.UserId, common.FormatQuota(userQuota), relayInfo.TokenId, tokenQuota))
+				common.LogInfo(c, fmt.Sprintf("user %d quota %s and token %d quota %d are enough, trusted and no need to pre-consume", relayInfo.UserId, common.FormatQuota(totalQuota), relayInfo.TokenId, tokenQuota))
 			}
 		} else {
 			// in this case, we do not pre-consume quota
 			// because the user has enough quota
 			preConsumedQuota = 0
-			common.LogInfo(c, fmt.Sprintf("user %d with unlimited token has enough quota %s, trusted and no need to pre-consume", relayInfo.UserId, common.FormatQuota(userQuota)))
+			common.LogInfo(c, fmt.Sprintf("user %d with unlimited token has enough quota %s, trusted and no need to pre-consume", relayInfo.UserId, common.FormatQuota(totalQuota)))
 		}
 	}
 
@@ -415,12 +416,17 @@ func preConsumeQuota(c *gin.Context, preConsumedQuota int, relayInfo *relaycommo
 		if err != nil {
 			return 0, 0, service.OpenAIErrorWrapperLocal(err, "pre_consume_token_quota_failed", http.StatusForbidden)
 		}
-		err = model.DecreaseUserQuota(relayInfo.UserId, preConsumedQuota)
-		if err != nil {
-			return 0, 0, service.OpenAIErrorWrapperLocal(err, "decrease_user_quota_failed", http.StatusInternalServerError)
+		subscriptionUsed, quotaUsed, consumeErr := model.ConsumeUserQuota(relayInfo.UserId, preConsumedQuota)
+		if consumeErr != nil {
+			rollbackErr := model.IncreaseTokenQuota(relayInfo.TokenId, relayInfo.TokenKey, preConsumedQuota)
+			if rollbackErr != nil {
+				common.LogError(c, fmt.Sprintf("failed to rollback token pre-consume for user %d token %d: %s", relayInfo.UserId, relayInfo.TokenId, rollbackErr.Error()))
+			}
+			return 0, 0, service.OpenAIErrorWrapperLocal(consumeErr, "decrease_user_quota_failed", http.StatusInternalServerError)
 		}
+		relayInfo.TrackConsumedQuota(subscriptionUsed, quotaUsed)
 	}
-	return preConsumedQuota, userQuota, nil
+	return preConsumedQuota, totalQuota, nil
 }
 
 func returnPreConsumedQuota(c *gin.Context, relayInfo *relaycommon.RelayInfo, userQuota int, preConsumedQuota int) {

--- a/service/quota.go
+++ b/service/quota.go
@@ -394,8 +394,10 @@ func PreConsumeTokenQuota(relayInfo *relaycommon.RelayInfo, quota int) error {
 
 func PostConsumeQuota(relayInfo *relaycommon.RelayInfo, quota int, preConsumedQuota int, sendEmail bool) (err error) {
 
+	var subscriptionUsed, quotaUsed int
 	if quota > 0 {
-		subscriptionUsed, quotaUsed, consumeErr := model.ConsumeUserQuota(relayInfo.UserId, quota)
+		var consumeErr error
+		subscriptionUsed, quotaUsed, consumeErr = model.ConsumeUserQuota(relayInfo.UserId, quota)
 		if consumeErr != nil {
 			return consumeErr
 		}
@@ -438,12 +440,23 @@ func PostConsumeQuota(relayInfo *relaycommon.RelayInfo, quota int, preConsumedQu
 
 	if !relayInfo.IsPlayground {
 		if quota > 0 {
-			err = model.DecreaseTokenQuota(relayInfo.TokenId, relayInfo.TokenKey, quota)
-		} else {
+			tokenErr := model.DecreaseTokenQuota(relayInfo.TokenId, relayInfo.TokenKey, quota)
+			if tokenErr != nil {
+				if subscriptionUsed > 0 || quotaUsed > 0 {
+					rollbackErr := model.RestoreUserQuota(relayInfo.UserId, subscriptionUsed, quotaUsed)
+					if rollbackErr != nil {
+						common.SysError(fmt.Sprintf("failed to rollback user quota for user %d after token consume error: %s", relayInfo.UserId, rollbackErr.Error()))
+					} else {
+						relayInfo.TrackRefundedQuota(subscriptionUsed, quotaUsed)
+					}
+				}
+				return tokenErr
+			}
+		} else if quota < 0 {
 			err = model.IncreaseTokenQuota(relayInfo.TokenId, relayInfo.TokenKey, -quota)
-		}
-		if err != nil {
-			return err
+			if err != nil {
+				return err
+			}
 		}
 	}
 

--- a/service/quota.go
+++ b/service/quota.go
@@ -94,10 +94,12 @@ func PreWssConsumeQuota(ctx *gin.Context, relayInfo *relaycommon.RelayInfo, usag
 	if relayInfo.UsePrice {
 		return nil
 	}
-	userQuota, err := model.GetUserQuota(relayInfo.UserId, false)
+	userBalance, err := model.GetUserQuotaBalance(relayInfo.UserId, false)
 	if err != nil {
 		return err
 	}
+	totalQuota := userBalance.Total()
+	relayInfo.UserQuota = totalQuota
 
 	token, err := model.GetTokenByKey(strings.TrimLeft(relayInfo.TokenKey, "sk-"), false)
 	if err != nil {
@@ -129,8 +131,8 @@ func PreWssConsumeQuota(ctx *gin.Context, relayInfo *relaycommon.RelayInfo, usag
 
 	quota := calculateAudioQuota(quotaInfo)
 
-	if userQuota < quota {
-		return fmt.Errorf("user quota is not enough, user quota: %s, need quota: %s", common.FormatQuota(userQuota), common.FormatQuota(quota))
+	if totalQuota < quota {
+		return fmt.Errorf("user quota is not enough, user quota: %s, need quota: %s", common.FormatQuota(totalQuota), common.FormatQuota(quota))
 	}
 
 	if !token.UnlimitedQuota && token.RemainQuota < quota {
@@ -393,12 +395,45 @@ func PreConsumeTokenQuota(relayInfo *relaycommon.RelayInfo, quota int) error {
 func PostConsumeQuota(relayInfo *relaycommon.RelayInfo, quota int, preConsumedQuota int, sendEmail bool) (err error) {
 
 	if quota > 0 {
-		err = model.DecreaseUserQuota(relayInfo.UserId, quota)
-	} else {
-		err = model.IncreaseUserQuota(relayInfo.UserId, -quota, false)
-	}
-	if err != nil {
-		return err
+		subscriptionUsed, quotaUsed, consumeErr := model.ConsumeUserQuota(relayInfo.UserId, quota)
+		if consumeErr != nil {
+			return consumeErr
+		}
+		relayInfo.TrackConsumedQuota(subscriptionUsed, quotaUsed)
+	} else if quota < 0 {
+		refundTotal := -quota
+		subscriptionRefund := 0
+		quotaRefund := 0
+		if relayInfo != nil {
+			if relayInfo.ConsumedSubscriptionQuota > 0 {
+				available := relayInfo.ConsumedSubscriptionQuota
+				if refundTotal < available {
+					subscriptionRefund = refundTotal
+				} else {
+					subscriptionRefund = available
+				}
+			}
+			refundTotal -= subscriptionRefund
+			if refundTotal > 0 && relayInfo.ConsumedQuota > 0 {
+				available := relayInfo.ConsumedQuota
+				if refundTotal < available {
+					quotaRefund = refundTotal
+				} else {
+					quotaRefund = available
+				}
+			}
+			refundTotal -= quotaRefund
+		}
+		if refundTotal > 0 {
+			quotaRefund += refundTotal
+		}
+		if subscriptionRefund > 0 || quotaRefund > 0 {
+			err = model.RestoreUserQuota(relayInfo.UserId, subscriptionRefund, quotaRefund)
+			if err != nil {
+				return err
+			}
+			relayInfo.TrackRefundedQuota(subscriptionRefund, quotaRefund)
+		}
 	}
 
 	if !relayInfo.IsPlayground {


### PR DESCRIPTION
- User 结构体新增 SubscriptionQuota 字段，支持订阅额度
- UserBase 缓存结构及相关缓存操作新增订阅额度字段
- UserQuotaBalance 结构体封装普通额度与订阅额度及总额度计算
- GetUserQuotaBalance 新增获取用户两类额度及总额度接口
- ConsumeUserQuota 新增从订阅额度和普通额度合并扣费逻辑，优先扣订阅额度
- RestoreUserQuota 新增订阅额度和普通额度分开退款逻辑
- RelayInfo 结构体新增消耗的订阅额度与普通额度追踪字段及方法
- 相关服务层逻辑修改为基于合并后的总额度判断和消费
- 修改预扣费逻辑，支持订阅额度和普通额度合并计算和消耗
- 优化错误处理，保证消费失败时令牌额度回滚
- 在 quota.go、relay-image.go、relay-text.go 等多处调整为支持订阅额度

此功能实现了订阅额度与普通额度的统一管理和消费，提升了
额度管理灵活性和准确性。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Per-user subscription quota added and combined with base quota for a single total quota.

- **Improvements**
  - All checks, messages and context now use the total quota for consistent behavior.
  - Quota consumption is atomic with automatic rollback on failures and explicit consumption tracking.
  - Relay metadata now reflects detailed consumed vs base quota for accurate downstream reporting.

- **Bug Fixes**
  - Image requests surface clear errors on quota retrieval failures.
  - Prevents overconsumption and negative balances during consume/refund flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->