### PR TITLE
fix(relay): Claude/AWS Bedrock 渠道支持日志记录对话内容

### DIFF
--- a/relay/channel/claude/relay-claude.go
+++ b/relay/channel/claude/relay-claude.go
@@ -101,6 +101,42 @@ func extractSystemPrompt(msgMap map[string]interface{}) string {
 	return ""
 }
 
+// appendSystemPrompt 将新的 system prompt 追加到现有的 prompt 中。
+//
+// 参数:
+//   - current: 当前已有的 system prompt
+//   - new: 新的 system prompt
+//
+// 返回值:
+//   - string: 合并后的 system prompt,用换行符分隔
+func appendSystemPrompt(current, new string) string {
+	if new == "" {
+		return current
+	}
+	if current == "" {
+		return new
+	}
+	return current + "\n" + new
+}
+
+// categorizeMessage 根据消息角色和位置对消息进行分类。
+//
+// 参数:
+//   - msgMap: 消息对象
+//   - role: 消息角色
+//   - index: 消息在列表中的索引
+//   - lastUserIndex: 最后一条用户消息的索引
+//
+// 返回值:
+//   - isUserMessage: 是否是最后一条用户消息
+//   - isContextMessage: 是否应作为上下文消息
+func categorizeMessage(role interface{}, index, lastUserIndex int) (isUserMessage, isContextMessage bool) {
+	if role == "user" {
+		return index == lastUserIndex, index != lastUserIndex
+	}
+	return false, role != "system"
+}
+
 // processMessages 处理消息列表,按角色分类提取不同的消息内容。
 // 遍历所有消息,将它们分类为: system prompt(合并所有 system 消息)、
 // user message(最后一条用户消息)和 context messages(其他所有消息)。
@@ -125,23 +161,17 @@ func processMessages(messages []interface{}, lastUserMessageIndex int) (systemPr
 			continue
 		}
 
-		switch role {
-		case "system":
-			prompt := extractSystemPrompt(msgMap)
-			if prompt != "" {
-				if systemPrompt == "" {
-					systemPrompt = prompt
-				} else {
-					systemPrompt += "\n" + prompt
-				}
-			}
-		case "user":
-			if i == lastUserMessageIndex {
-				userMessage = msgMap
-			} else {
-				contextMessages = append(contextMessages, msgMap)
-			}
-		default:
+		// 处理 system 消息
+		if role == "system" {
+			systemPrompt = appendSystemPrompt(systemPrompt, extractSystemPrompt(msgMap))
+			continue
+		}
+
+		// 分类其他消息
+		isUser, isContext := categorizeMessage(role, i, lastUserMessageIndex)
+		if isUser {
+			userMessage = msgMap
+		} else if isContext {
 			contextMessages = append(contextMessages, msgMap)
 		}
 	}


### PR DESCRIPTION
- 新增 extractConversationContent 函数提取对话内容到 info.Other
- 在 HandleStreamFinalResponse 和 HandleClaudeResponseData 中调用该函数
- 修复流式处理中 Thinking 内容缺失问题
- 确保流式和非流式处理都记录完整的对话内容(包括 Thinking)

修复后,启用 LogChatContentEnabled 设置时,Claude 和 AWS Bedrock 渠道 的对话内容将正确记录到日志的 other 字段中

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced conversation logging to consistently capture system prompts, last user input, contextual messages, and final outputs.
  * Aggregates incremental “thinking” and streamed response fragments so reasoning traces appear coherently in logs and transcripts.
  * Persists input, context, and output together across streaming and non-streaming responses for clearer tracking and more accurate post-session review.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->